### PR TITLE
CI: fix tests not running

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,8 +6,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-24.04
-    container: ubuntu
+    runs-on: ubuntu-latest
 
     services:
       couchdb:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     container: ubuntu
 
     services:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    container: ubuntu:24.04
 
     services:
       couchdb:


### PR DESCRIPTION
Tests haven't been running for several weeks due to an Ubuntu version mismatch. This PR locks the container used to run tests and linting to Ubuntu 24.04--the `ruby/setup-ruby` action logs a "not supported" message on Ubuntu 26.