### PR TITLE
Fix device-pairing button (Turbo ignored the 200 response)

### DIFF
--- a/app/views/account/show.html.erb
+++ b/app/views/account/show.html.erb
@@ -29,7 +29,9 @@
       </div>
     <% end %>
 
-    <%= form_with url: account_pairing_code_path, method: :post, class: 'flex items-end gap-2 mb-6' do |f| %>
+    <%# turbo: false so the rendered page (which shows the new code) is displayed —
+        Turbo ignores 200 responses to form POSTs. %>
+    <%= form_with url: account_pairing_code_path, method: :post, data: { turbo: false }, class: 'flex items-end gap-2 mb-6' do |f| %>
       <div class="flex-1">
         <%= f.label :device_name, 'Device name (optional)', class: 'block text-sm text-gray-600 mb-1' %>
         <%= f.text_field :device_name, placeholder: 'e.g. Field iPad',


### PR DESCRIPTION
The generate-code form was Turbo-driven but the action renders (200) to show the code; Turbo ignores 200s on form POSTs, so the button did nothing. `data: { turbo: false }` makes it a normal submit. Confirmed superuser-paired devices receive every dig.