### PR TITLE
Fix pairing-code refresh error (POST->redirect->GET)

### DIFF
--- a/app/controllers/account_controller.rb
+++ b/app/controllers/account_controller.rb
@@ -3,13 +3,14 @@ class AccountController < ApplicationController
 
   def show
     @devices = Device.for_user(current_user.id_as_string)
+    @pairing_code = active_pairing_code(params[:code])
   end
 
-  # Generate a short-lived pairing code for the current user to enter on a device.
+  # Generate a short-lived pairing code, then redirect (POST->redirect->GET) so the
+  # resulting URL (/account?code=...) is refreshable instead of the POST-only route.
   def create_pairing_code
-    @pairing_code = PairingCode.generate_for(current_user, device_name: params[:device_name])
-    @devices = Device.for_user(current_user.id_as_string)
-    render :show
+    code = PairingCode.generate_for(current_user, device_name: params[:device_name])
+    redirect_to account_path(code: code.code), status: :see_other
   end
 
   # Polled by the account page to close the "did it work?" loop: a pending code
@@ -35,5 +36,16 @@ class AccountController < ApplicationController
       flash[:alert] = 'Device not found.'
     end
     redirect_to account_path
+  end
+
+  private
+
+  # The current user's pairing code from the ?code= param, only if it's still
+  # active and belongs to them (so a stale/foreign code in the URL shows nothing).
+  def active_pairing_code(raw_code)
+    return if raw_code.blank?
+
+    code = PairingCode.find(raw_code)
+    code if code&.active? && code.user_id == current_user.id_as_string
   end
 end

--- a/app/views/account/show.html.erb
+++ b/app/views/account/show.html.erb
@@ -29,9 +29,7 @@
       </div>
     <% end %>
 
-    <%# turbo: false so the rendered page (which shows the new code) is displayed —
-        Turbo ignores 200 responses to form POSTs. %>
-    <%= form_with url: account_pairing_code_path, method: :post, data: { turbo: false }, class: 'flex items-end gap-2 mb-6' do |f| %>
+    <%= form_with url: account_pairing_code_path, method: :post, class: 'flex items-end gap-2 mb-6' do |f| %>
       <div class="flex-1">
         <%= f.label :device_name, 'Device name (optional)', class: 'block text-sm text-gray-600 mb-1' %>
         <%= f.text_field :device_name, placeholder: 'e.g. Field iPad',

--- a/spec/controllers/account_controller_spec.rb
+++ b/spec/controllers/account_controller_spec.rb
@@ -17,15 +17,46 @@ RSpec.describe AccountController, type: :controller do
   end
 
   describe 'POST create_pairing_code' do
-    it 'generates a pairing code owned by the current user' do
+    it 'generates a code and redirects (POST->redirect->GET) so refresh is safe' do
       session[:user_id] = users[:viewer].id
 
       post :create_pairing_code, params: { device_name: 'iPad' }
 
-      expect(response).to be_successful
-      expect(assigns(:pairing_code).user_id).to eq(users[:viewer].id_as_string)
+      expect(response).to have_http_status(:see_other)
+      code_param = Rack::Utils.parse_query(URI.parse(response.location).query)['code']
+      expect(code_param).to be_present
+
+      code = PairingCode.find(code_param)
+      expect(code.user_id).to eq(users[:viewer].id_as_string)
     ensure
-      assigns(:pairing_code)&.destroy!
+      code&.destroy!
+    end
+  end
+
+  describe 'GET show with ?code=' do
+    it "renders the current user's active pairing code from the redirect" do
+      session[:user_id] = users[:viewer].id
+      code = PairingCode.generate_for(users[:viewer])
+
+      get :show, params: { code: code.code }
+
+      expect(response).to be_successful
+      expect(assigns(:pairing_code)&.code).to eq(code.code)
+      expect(response.body).to include(code.code)
+    ensure
+      code&.destroy!
+    end
+
+    it "ignores a code that belongs to another user" do
+      session[:user_id] = users[:viewer].id
+      other = PairingCode.generate_for(users[:registrar])
+
+      get :show, params: { code: other.code }
+
+      expect(response).to be_successful
+      expect(assigns(:pairing_code)).to be_nil
+    ensure
+      other&.destroy!
     end
   end
 


### PR DESCRIPTION
## Problem

Refreshing the account page after starting device pairing raised:

```
ActionController::RoutingError (No route matches [GET] "/account/pairing_code")
```

`create_pairing_code` rendered `:show` in response to the POST, so the browser URL stayed at `/account/pairing_code` — a **POST-only** route. Refreshing re-issued it as a GET → no matching route.

## Fix

Proper **POST → redirect → GET**:
- `create_pairing_code` generates the code and `redirect_to account_path(code: ...), status: :see_other`. The resulting URL (`/account?code=...`) is refreshable.
- `show` loads the code from `params[:code]`, but only if it's still active **and** belongs to the current user (stale/foreign codes in the URL render nothing).
- Removed `data: { turbo: false }` from the form — the 303 redirect is the standard Turbo flow, so Turbo follows it natively.

## Tests

Updated `account_controller_spec`: asserts the 303 redirect carries a `code` param owned by the user, that `show?code=` renders the active code, and that a foreign code is ignored. 8 examples, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)