### PR TITLE
Push S3 + storage config to paired devices

### DIFF
--- a/app/services/device_configuration.rb
+++ b/app/services/device_configuration.rb
@@ -1,11 +1,13 @@
 # Builds the configuration bundle handed to a paired mobile device. The device
-# uses this to sync directly with CouchDB and render images via imgproxy itself,
-# so the bundle carries the database credentials, the imgproxy info, the
-# forms/lookups config, and the user's per-project role/scope.
+# uses this to sync directly with CouchDB, upload/fetch artifacts and daily
+# photos straight to/from S3, and render images via imgproxy itself, so the
+# bundle carries the database credentials, the S3 bucket + credentials, the
+# imgproxy info, the forms/lookups config, and the user's per-project role/scope.
 #
 # SECURITY: per the chosen "fast" path this includes the shared master CouchDB
-# credentials (full access to all project databases) and the imgproxy signing
-# secrets. Acceptable for a prototype only -- see the plan's security note.
+# credentials (full access to all project databases), the S3 access keys, and the
+# imgproxy signing secrets. Acceptable for a prototype only -- see the plan's
+# security note (per-user scoped creds are the recommended follow-up).
 class DeviceConfiguration
   def initialize(user)
     @user = user
@@ -16,6 +18,7 @@ class DeviceConfiguration
       'user' => { 'email' => @user.email, 'name' => @user.name },
       'imgproxy' => imgproxy_config,
       'couchdb' => couchdb_config,
+      's3' => s3_config,
       'descriptions' => Rails.application.config.descriptions,
       'projects' => projects
     }
@@ -39,13 +42,44 @@ class DeviceConfiguration
         # roles entry; otherwise report the user's stored role for that project.
         'role' => superuser ? 'superuser' : @user.role_for(key),
         'scopes' => @user.scopes_for(key),
-        'database' => Project.database_name(key)
+        'database' => Project.database_name(key),
+        'storage' => storage_prefixes(key)
+      }
+    end
+  end
+
+  # Where this project's files live in the shared bucket. Resolved through
+  # ProjectStorage so the device keys objects exactly as the server does.
+  def storage_prefixes(key)
+    CouchDB.with_project(key) do
+      {
+        'artifacts_prefix' => ProjectStorage.artifacts_prefix,
+        'daily_photos_prefix' => ProjectStorage.daily_photos_prefix
       }
     end
   end
 
   def imgproxy_config
     { 'url' => ENV.fetch('IMGPROXY_URL', nil), 'key' => ENV.fetch('IMGPROXY_KEY', nil), 'salt' => ENV.fetch('IMGPROXY_SALT', nil) }
+  end
+
+  # The shared S3 bucket the device uploads to / fetches from directly. endpoint
+  # is nil for real AWS and set (force_path_style) for a custom endpoint like the
+  # dev minio. Objects are written public-read, matching server-side uploads.
+  def s3_config
+    {
+      'bucket' => bucket_name,
+      'region' => ENV.fetch('AWS_REGION', 'us-east-1'),
+      'endpoint' => ENV['S3_URL'].presence,
+      'force_path_style' => ENV['S3_URL'].present?,
+      'access_key_id' => ENV.fetch('AWS_ACCESS_KEY_ID', nil),
+      'secret_access_key' => ENV.fetch('AWS_SECRET_ACCESS_KEY', nil),
+      'acl' => 'public-read'
+    }
+  end
+
+  def bucket_name
+    Rails.application.config.try(:s3_bucket)&.name || ENV.fetch('S3_BUCKET', 'opendig')
   end
 
   def couchdb_config

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -85,3 +85,14 @@ def load_user_fixtures
     User.new(attrs, persist: false) # Load into memory only (much faster than saving to DB)
   end.to_h.with_indifferent_access
 end
+
+# Temporarily set ENV vars for the duration of the block, restoring prior values
+# afterwards. A nil value unsets the variable. Used to exercise config that reads
+# from the environment (e.g. the device S3 bundle).
+def with_env(vars)
+  previous = vars.keys.index_with { |k| ENV.fetch(k, nil) }
+  vars.each { |k, v| v.nil? ? ENV.delete(k) : ENV[k] = v }
+  yield
+ensure
+  previous.each { |k, v| v.nil? ? ENV.delete(k) : ENV[k] = v }
+end

--- a/spec/services/device_configuration_spec.rb
+++ b/spec/services/device_configuration_spec.rb
@@ -5,14 +5,38 @@ RSpec.describe DeviceConfiguration do
 
   before { allow(Project).to receive(:all).and_return(%w[opendig balua]) }
 
-  it 'lists the projects the user has a role in, with role and scope' do
+  it 'lists the projects the user has a role in, with role, scope and storage prefixes' do
     config = described_class.new(users[:area_supervisor]).as_json
 
     project = config['projects'].find { |p| p['key'] == 'opendig' }
     expect(project['role']).to eq('area_supervisor')
     expect(project['scopes']).to eq(['1'])
     expect(project['database']).to eq('opendig_test')
+    expect(project['storage']).to eq(
+      'artifacts_prefix' => 'opendig/artifacts',
+      'daily_photos_prefix' => 'opendig/daily_photos'
+    )
     expect(config['projects'].map { |p| p['key'] }).not_to include('balua') # not a member
+  end
+
+  it 'includes the shared S3 bucket, region and credentials for direct upload' do
+    config = with_env('S3_BUCKET' => 'opendig', 'S3_URL' => 'http://minio:9000',
+                      'AWS_ACCESS_KEY_ID' => 'AKIA', 'AWS_SECRET_ACCESS_KEY' => 'secret') do
+      described_class.new(users[:dig_director]).as_json
+    end
+
+    expect(config['s3']).to include(
+      'bucket' => 'opendig', 'region' => 'us-east-1', 'endpoint' => 'http://minio:9000',
+      'force_path_style' => true, 'access_key_id' => 'AKIA',
+      'secret_access_key' => 'secret', 'acl' => 'public-read'
+    )
+  end
+
+  it 'reports no S3 endpoint (real AWS) when S3_URL is unset' do
+    config = with_env('S3_URL' => nil) { described_class.new(users[:dig_director]).as_json }
+
+    expect(config['s3']['endpoint']).to be_nil
+    expect(config['s3']['force_path_style']).to be(false)
   end
 
   it 'gives a superuser every project, as superuser' do


### PR DESCRIPTION
## Why

A paired device syncs CouchDB and renders images via imgproxy itself — but the config bundle gave it **nothing for S3**. Without the bucket, credentials, and per-project key prefixes, a device can't upload finds/daily-photos or build its own object paths. This closes that gap so everything S3-related is pushed at pair time (and on every `/api/v1/config` refresh).

## What's added to the bundle

**Top-level `s3` block:**
```json
"s3": {
  "bucket": "opendig",
  "region": "us-east-1",
  "endpoint": null,            // set (force_path_style) for a custom endpoint like dev minio
  "force_path_style": false,
  "access_key_id": "...",
  "secret_access_key": "...",
  "acl": "public-read"        // matches server-side uploads
}
```

**Per-project `storage` prefixes** (resolved through `ProjectStorage` so the device keys objects *exactly* as the server does):
```json
"storage": {
  "artifacts_prefix": "balua/artifacts",
  "daily_photos_prefix": "balua/daily_photos"
}
```

So a device can upload to `s3://opendig/balua/artifacts/...` and build imgproxy URLs against `s3://opendig/balua/daily_photos/...` — same paths the web app uses.

## Security note

Per the agreed prototype "fast path," this hands devices the shared S3 access keys (alongside the shared CouchDB creds and imgproxy secrets already in the bundle). Per-user scoped credentials remain the recommended follow-up; the class docstring flags it.

## Tests

`device_configuration_spec`: asserts the s3 block (bucket/region/keys/acl), the minio-vs-real-AWS endpoint branch, and the per-project storage prefixes. New `with_env` helper in `rails_helper`. Full suite: 203 examples, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)