### PR TITLE
Make S3 config Wasabi-explicit (no AWS assumptions)

### DIFF
--- a/app/services/device_configuration.rb
+++ b/app/services/device_configuration.rb
@@ -63,19 +63,42 @@ class DeviceConfiguration
     { 'url' => ENV.fetch('IMGPROXY_URL', nil), 'key' => ENV.fetch('IMGPROXY_KEY', nil), 'salt' => ENV.fetch('IMGPROXY_SALT', nil) }
   end
 
-  # The shared S3 bucket the device uploads to / fetches from directly. endpoint
-  # is nil for real AWS and set (force_path_style) for a custom endpoint like the
-  # dev minio. Objects are written public-read, matching server-side uploads.
+  # The shared S3-compatible object store the device uploads to / fetches from
+  # directly. We use Wasabi, not AWS, so the endpoint is explicit and the bundle
+  # carries a fully-qualified public_url_base -- the device must not assume an
+  # s3://bucket path resolves to AWS. force_path_style + public_url_base are
+  # path-style (https://<endpoint>/<bucket>/<key>), matching the app's own client
+  # and the imgproxy config. Objects are written public-read.
   def s3_config
     {
       'bucket' => bucket_name,
-      'region' => ENV.fetch('AWS_REGION', 'us-east-1'),
-      'endpoint' => ENV['S3_URL'].presence,
-      'force_path_style' => ENV['S3_URL'].present?,
+      'region' => s3_region,
+      'endpoint' => s3_endpoint,
+      'force_path_style' => true,
+      'public_url_base' => public_url_base,
       'access_key_id' => ENV.fetch('AWS_ACCESS_KEY_ID', nil),
       'secret_access_key' => ENV.fetch('AWS_SECRET_ACCESS_KEY', nil),
       'acl' => 'public-read'
     }
+  end
+
+  # Fully-qualified base for direct object URLs: <endpoint>/<bucket>. The device
+  # appends a storage prefix + key (e.g. .../opendig/balua/daily_photos/12.JPG)
+  # with no scheme assumptions. Falls back to AWS virtual-hosted style only if no
+  # endpoint is configured (i.e. genuinely on AWS).
+  def public_url_base
+    endpoint = s3_endpoint
+    return "https://#{bucket_name}.s3.#{s3_region}.amazonaws.com" if endpoint.blank?
+
+    "#{endpoint.chomp('/')}/#{bucket_name}"
+  end
+
+  def s3_endpoint
+    ENV['S3_URL'].presence
+  end
+
+  def s3_region
+    ENV.fetch('AWS_REGION', 'us-east-1')
   end
 
   def bucket_name

--- a/config/initializers/s3_bucket.rb
+++ b/config/initializers/s3_bucket.rb
@@ -3,6 +3,9 @@ require 'aws-sdk-s3'
 require 'imgproxy'
 
 if Rails.env.production?
+  # We use Wasabi (S3-compatible), so the endpoint and region must be explicit --
+  # never assume AWS. S3_URL is the Wasabi endpoint (e.g.
+  # https://s3.<region>.wasabisys.com); AWS_REGION must match it.
   if ENV['S3_URL']
     Aws.config.update(
       endpoint: ENV['S3_URL'],
@@ -11,9 +14,9 @@ if Rails.env.production?
   end
 
   Aws.config.update(
-    region: 'us-east-1'
+    region: ENV.fetch('AWS_REGION', 'us-east-1')
   )
-  
+
   s3 = Aws::S3::Resource.new
 
   # One universal bucket for all projects; project scoping happens in the object

--- a/spec/services/device_configuration_spec.rb
+++ b/spec/services/device_configuration_spec.rb
@@ -2,6 +2,10 @@ require 'rails_helper'
 
 RSpec.describe DeviceConfiguration do
   let(:users) { load_user_fixtures }
+  let(:wasabi_env) do
+    { 'S3_BUCKET' => 'opendig', 'S3_URL' => 'https://s3.eu-central-1.wasabisys.com',
+      'AWS_REGION' => 'eu-central-1', 'AWS_ACCESS_KEY_ID' => 'AKIA', 'AWS_SECRET_ACCESS_KEY' => 'secret' }
+  end
 
   before { allow(Project).to receive(:all).and_return(%w[opendig balua]) }
 
@@ -19,24 +23,24 @@ RSpec.describe DeviceConfiguration do
     expect(config['projects'].map { |p| p['key'] }).not_to include('balua') # not a member
   end
 
-  it 'includes the shared S3 bucket, region and credentials for direct upload' do
-    config = with_env('S3_BUCKET' => 'opendig', 'S3_URL' => 'http://minio:9000',
-                      'AWS_ACCESS_KEY_ID' => 'AKIA', 'AWS_SECRET_ACCESS_KEY' => 'secret') do
-      described_class.new(users[:dig_director]).as_json
-    end
+  it 'includes the Wasabi endpoint, region, credentials and a path-style base URL' do
+    config = with_env(wasabi_env) { described_class.new(users[:dig_director]).as_json }
 
     expect(config['s3']).to include(
-      'bucket' => 'opendig', 'region' => 'us-east-1', 'endpoint' => 'http://minio:9000',
-      'force_path_style' => true, 'access_key_id' => 'AKIA',
-      'secret_access_key' => 'secret', 'acl' => 'public-read'
+      'bucket' => 'opendig', 'region' => 'eu-central-1',
+      'endpoint' => 'https://s3.eu-central-1.wasabisys.com', 'force_path_style' => true,
+      'public_url_base' => 'https://s3.eu-central-1.wasabisys.com/opendig',
+      'access_key_id' => 'AKIA', 'secret_access_key' => 'secret', 'acl' => 'public-read'
     )
   end
 
-  it 'reports no S3 endpoint (real AWS) when S3_URL is unset' do
-    config = with_env('S3_URL' => nil) { described_class.new(users[:dig_director]).as_json }
+  it 'falls back to an AWS virtual-hosted base URL only when no endpoint is set' do
+    config = with_env('S3_BUCKET' => 'opendig', 'S3_URL' => nil, 'AWS_REGION' => 'us-east-1') do
+      described_class.new(users[:dig_director]).as_json
+    end
 
     expect(config['s3']['endpoint']).to be_nil
-    expect(config['s3']['force_path_style']).to be(false)
+    expect(config['s3']['public_url_base']).to eq('https://opendig.s3.us-east-1.amazonaws.com')
   end
 
   it 'gives a superuser every project, as superuser' do


### PR DESCRIPTION
We store files in **Wasabi** (S3-compatible), not AWS — so neither the app nor the device bundle can assume an `s3://bucket` path resolves to AWS.

## Changes
- **`config/initializers/s3_bucket.rb`**: region now comes from `AWS_REGION` (was hardcoded `us-east-1`), so the S3 client signs requests for Wasabi's actual region. Endpoint already comes from `S3_URL`.
- **`DeviceConfiguration`**: the `s3` block is endpoint-explicit and now includes a fully-qualified **`public_url_base`** (`<endpoint>/<bucket>`, path-style) that the device appends storage prefixes + keys to — e.g. `https://s3.<region>.wasabisys.com/opendig/balua/daily_photos/12.JPG`. No `s3://` scheme guessing. Falls back to AWS virtual-hosted style only if no endpoint is set.

## Still required (ops, separate from this PR)
Production must set `S3_URL` (the Wasabi endpoint) and `AWS_REGION` to match — currently neither is set, so prod would talk to AWS. Tracking that in the infra repo.

## Tests
`device_configuration_spec`: asserts the Wasabi endpoint/region/path-style base URL and the AWS-fallback base URL. 5 examples, 0 failures; rubocop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)