### PR TITLE
Add user_photos storage category (device-only field photos)

### DIFF
--- a/app/models/concerns/project_storage.rb
+++ b/app/models/concerns/project_storage.rb
@@ -1,6 +1,10 @@
+require "securerandom"
+
 # Project-scoped S3 object-key prefixes. All projects share one bucket (default
-# "opendig"); each project's files live under <project>/artifacts/... (find images)
-# and <project>/daily_photos/... so projects never collide. The project is the one
+# "opendig"); each project's files live under <project>/artifacts/... (find images),
+# <project>/daily_photos/... (official daily photos) and <project>/user_photos/...
+# (unofficial field photos taken on a paired device) so projects -- and the
+# official vs. user photo categories -- never collide. The project is the one
 # resolved from the request subdomain (CouchDB.current_project).
 module ProjectStorage
   module_function
@@ -18,5 +22,27 @@ module ProjectStorage
 
   def daily_photos_prefix
     "#{storage_project}/daily_photos"
+  end
+
+  # Unofficial, device-only field photos. Kept under a distinct prefix so they
+  # are always separable from the official daily_photos and can be displayed
+  # apart from them.
+  def user_photos_prefix
+    "#{storage_project}/user_photos"
+  end
+
+  # Canonical key for a user-taken field photo. Self-describing so an object is
+  # attributable even detached from its locus record: locus, uploader and capture
+  # time are encoded, with a short random nonce so burst/offline shots in the same
+  # second never collide. Devices generate names to this same contract offline.
+  def user_photo_key(locus:, user_id:, taken_at:, ext: "jpg", nonce: SecureRandom.hex(3))
+    stamp = taken_at.utc.strftime("%Y%m%dT%H%M%SZ")
+    name  = "#{key_slug(locus)}-#{key_slug(user_id)}-#{stamp}-#{nonce}.#{ext.to_s.downcase.delete_prefix('.')}"
+    "#{user_photos_prefix}/#{name}"
+  end
+
+  # Reduce an identifier to characters safe and predictable in an object key.
+  def key_slug(value)
+    value.to_s.strip.gsub(/[^a-zA-Z0-9]+/, "_").gsub(/\A_+|_+\z/, "")
   end
 end

--- a/app/services/device_configuration.rb
+++ b/app/services/device_configuration.rb
@@ -54,7 +54,8 @@ class DeviceConfiguration
     CouchDB.with_project(key) do
       {
         'artifacts_prefix' => ProjectStorage.artifacts_prefix,
-        'daily_photos_prefix' => ProjectStorage.daily_photos_prefix
+        'daily_photos_prefix' => ProjectStorage.daily_photos_prefix,
+        'user_photos_prefix' => ProjectStorage.user_photos_prefix
       }
     end
   end

--- a/spec/models/project_storage_spec.rb
+++ b/spec/models/project_storage_spec.rb
@@ -6,11 +6,40 @@ RSpec.describe ProjectStorage do
 
     expect(described_class.artifacts_prefix).to eq('balua/artifacts')
     expect(described_class.daily_photos_prefix).to eq('balua/daily_photos')
+    expect(described_class.user_photos_prefix).to eq('balua/user_photos')
   end
 
   it 'raises when no project is resolved (never writes to an unscoped path)' do
     CouchDB.current_project = nil
 
     expect { described_class.storage_project }.to raise_error(/No current project/)
+  end
+
+  describe '.user_photo_key' do
+    before { CouchDB.current_project = 'balua' }
+
+    it 'builds a self-describing, collision-resistant field-photo key' do
+      key = described_class.user_photo_key(
+        locus: 'L1023', user_id: 'u8f2a',
+        taken_at: Time.utc(2026, 6, 19, 14, 33, 55), nonce: '3b9c'
+      )
+
+      expect(key).to eq('balua/user_photos/L1023-u8f2a-20260619T143355Z-3b9c.jpg')
+    end
+
+    it 'normalises unsafe characters and the extension' do
+      key = described_class.user_photo_key(
+        locus: 'Area 1/Sq 2', user_id: 'user@x.com',
+        taken_at: Time.utc(2026, 1, 2, 3, 4, 5), ext: '.JPEG', nonce: 'ab12'
+      )
+
+      expect(key).to eq('balua/user_photos/Area_1_Sq_2-user_x_com-20260102T030405Z-ab12.jpeg')
+    end
+
+    it 'generates a unique nonce per call by default' do
+      args = { locus: 'L1', user_id: 'u1', taken_at: Time.utc(2026, 1, 1) }
+
+      expect(described_class.user_photo_key(**args)).not_to eq(described_class.user_photo_key(**args))
+    end
   end
 end

--- a/spec/services/device_configuration_spec.rb
+++ b/spec/services/device_configuration_spec.rb
@@ -17,8 +17,8 @@ RSpec.describe DeviceConfiguration do
     expect(project['scopes']).to eq(['1'])
     expect(project['database']).to eq('opendig_test')
     expect(project['storage']).to eq(
-      'artifacts_prefix' => 'opendig/artifacts',
-      'daily_photos_prefix' => 'opendig/daily_photos'
+      'artifacts_prefix' => 'opendig/artifacts', 'daily_photos_prefix' => 'opendig/daily_photos',
+      'user_photos_prefix' => 'opendig/user_photos'
     )
     expect(config['projects'].map { |p| p['key'] }).not_to include('balua') # not a member
   end


### PR DESCRIPTION
Establishes the third object-storage category from the design we settled on.

## Tree
```
<project>/
  artifacts/<registration_number>…     OFFICIAL find photos
  daily_photos/<number>.JPG            OFFICIAL daily photos (flat, by photo ID — as today)
  user_photos/<generated-name>.jpg     UNOFFICIAL field photos (device-only)
```

A **separate top-level prefix** is what guarantees user/field photos never mix with the official record and can always be displayed apart from it.

## Generated name
Self-describing so an object is attributable even detached from its locus record, with a random nonce for offline/burst collisions:
```
user_photos/L1023-u8f2a-20260619T143355Z-3b9c.jpg
            └loc┘ └user┘ └──UTC stamp───┘ └rand┘
```
`ProjectStorage.user_photo_key(locus:, user_id:, taken_at:, ext:, nonce:)` is the canonical contract; devices generate to the same shape offline. Unsafe chars and the extension are normalised.

## Bundle
The per-project `storage` block now publishes `user_photos_prefix` alongside `artifacts_prefix` / `daily_photos_prefix`, so a paired device knows where to write.

## Not in this PR (follow-ups)
- **Linking**: attach photo refs (`{key, category}`) to the **locus CouchDB record** so the locus page can render official vs. field photos separately. The naming/category here is forward-compatible with that.
- **Migrating official daily photos** onto the locus record (the larger change you flagged) — separate.

## Tests
`project_storage_spec`: prefix + key generation (format, normalisation, nonce uniqueness). `device_configuration_spec`: `user_photos_prefix` in the bundle. 206 examples, 0 failures; rubocop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)