### PR TITLE
Display device field photos on the locus page, separate from official

### DIFF
--- a/app/models/photo.rb
+++ b/app/models/photo.rb
@@ -36,6 +36,18 @@ class Photo
     end
   end
 
+  # Imgproxy URL for an arbitrary object key, e.g. a user/field photo stored
+  # under <project>/user_photos/.... Unlike official daily photos there is no
+  # number -> daily_photos mapping; the caller passes the full key recorded on
+  # the locus, and the object is taken to exist (it's referenced in the record).
+  def self.url_for_key(key, style)
+    Rails.cache.fetch "photo_url_key_#{key}_#{style}" do
+      photo_style = styles(style)
+      builder = Imgproxy::Builder.new(photo_style.transform_keys(&:to_sym))
+      builder.url_for("s3://#{Rails.application.config.s3_bucket.name}/#{key}")
+    end
+  end
+
   def self.visible_loci(number)
     db = CouchDB.main_db
 

--- a/app/views/loci/_user_photos.html.erb
+++ b/app/views/loci/_user_photos.html.erb
@@ -1,0 +1,34 @@
+<div class="flex flex-col mb-8 bg-amber-50 border border-amber-200 p-4 rounded-lg shadow">
+  <div class="flex items-center flex-wrap gap-3 mb-6">
+    <h1 class="text-2xl font-bold">Field Photos</h1>
+    <span class="text-xs font-medium uppercase tracking-wide text-amber-800 bg-amber-100 border border-amber-300 rounded-full px-2 py-0.5">
+      Unofficial &middot; uploaded from the field
+    </span>
+  </div>
+  <div class="overflow-x-auto">
+    <table class="table w-full">
+      <thead>
+        <tr>
+          <th class="px-4 py-2 text-left">Date</th>
+          <th class="px-4 py-2 text-left">Uploaded by</th>
+          <th class="px-4 py-2 text-left">Subject</th>
+          <th class="px-4 py-2 text-center">Photo</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% @locus.dig('user_photos').each do |photo| %>
+          <tr class="hover:bg-amber-100">
+            <td class="px-4 py-2 text-left"><%= read_date(photo["taken_at"]) %></td>
+            <td class="px-4 py-2 text-left"><%= photo["user_name"].presence || photo["user"] %></td>
+            <td class="px-4 py-2 text-left"><%= photo["subject"] %></td>
+            <td class="px-4 py-2 text-center">
+              <a class="locus-photo-link flex justify-center" href="<%= Photo.url_for_key(photo["key"], :medium) %>" data-lightbox="locus-field-photos">
+                <img class="locus-photo w-32 h-32 object-cover rounded" src="<%= Photo.url_for_key(photo["key"], :thumb) %>" alt="" />
+              </a>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/app/views/loci/show.html.erb
+++ b/app/views/loci/show.html.erb
@@ -47,4 +47,5 @@
   <%= render 'pottery' if @locus["pottery"] %>
   <%= render 'pails' if @locus["pails"] %>
   <%= render 'photos' if @locus["photos"] %>
+  <%= render 'user_photos' if @locus["user_photos"].present? %>
 </div>

--- a/spec/views/loci/_user_photos.html.erb_spec.rb
+++ b/spec/views/loci/_user_photos.html.erb_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe 'loci/_user_photos', type: :view do
+  let(:field_photo) do
+    { 'key' => 'balua/user_photos/L1-u8-20260619T143355Z-3b9c.jpg',
+      'user' => 'u8', 'user_name' => 'Field Lead',
+      'taken_at' => '2026-06-19T14:33:55Z', 'subject' => 'north baulk' }
+  end
+
+  before do
+    # Avoid building real imgproxy URLs (needs S3 config); assert on the key/style.
+    allow(Photo).to receive(:url_for_key) { |key, style| "https://img.test/#{key}/#{style}" }
+  end
+
+  it 'renders field photos in a distinct unofficial section with attribution' do
+    assign(:locus, { 'user_photos' => [field_photo] })
+
+    render partial: 'loci/user_photos'
+
+    expect(rendered).to include('Field Photos')
+    expect(rendered).to match(/Unofficial/i)
+    expect(rendered).to include('Field Lead')   # uploader attribution
+    expect(rendered).to include('north baulk')  # subject
+    expect(rendered).to include('19 Jun, 2026') # read_date(taken_at)
+    expect(rendered).to include('https://img.test/balua/user_photos/L1-u8-20260619T143355Z-3b9c.jpg/thumb')
+  end
+
+  it 'falls back to the user id when no display name is recorded' do
+    assign(:locus, {
+             'user_photos' => [
+               { 'key' => 'balua/user_photos/x.jpg', 'user' => 'u8', 'taken_at' => '2026-06-19T00:00:00Z' }
+             ]
+           })
+
+    render partial: 'loci/user_photos'
+
+    expect(rendered).to include('u8')
+  end
+end


### PR DESCRIPTION
Turns the `user_photos` storage category (#40) into something visible: field photos taken on a paired device now show on the locus page in their **own section**, clearly separated from the official daily photos.

## Linkage (the part requested)
The locus CouchDB record carries an optional **`user_photos`** array alongside the official `photos` array:
```json
"user_photos": [
  { "key": "balua/user_photos/L1023-u8f2a-20260619T143355Z-3b9c.jpg",
    "user": "u8f2a", "user_name": "Field Lead",
    "taken_at": "2026-06-19T14:33:55Z", "subject": "north baulk" }
]
```
Devices write this via CouchDB sync; the web app only **displays** it — upload stays device-only.

## Display
- New `loci/_user_photos` partial renders a distinct **"Field Photos"** section (amber-tinted, badged *"Unofficial · uploaded from the field"*) with date / uploader / subject / thumbnail.
- `show.html.erb` renders it only when `user_photos` is present, right after — and visually apart from — the official `photos` section.
- `Photo.url_for_key(key, style)` builds the imgproxy URL from the **full object key** recorded on the locus (field photos have no daily-photo number to look up).

## Tests
View spec for the partial: distinct unofficial section, uploader attribution (with user-id fallback), subject, formatted date, and the keyed thumbnail URL. 208 examples, 0 failures; Ruby files rubocop-clean.

## Follow-up (unchanged from #40)
Migrating the **official** daily photos onto the locus record (so the flat-ID `Photo` lookup becomes optional) remains a separate, larger change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)