### PR TITLE
Rename 'artifacts' storage category to 'finds'

### DIFF
--- a/app/controllers/bulk_uploads_controller.rb
+++ b/app/controllers/bulk_uploads_controller.rb
@@ -9,7 +9,7 @@ class BulkUploadsController < ApplicationController
     uploaded_file_keys = []
     bucket = Rails.application.config.s3_bucket
     uploaded_files.each do |file|
-      s3_object = bucket.object("#{ProjectStorage.artifacts_prefix}/#{file.original_filename}")
+      s3_object = bucket.object("#{ProjectStorage.finds_prefix}/#{file.original_filename}")
 
       s3_object.upload_file(file.tempfile.path, acl: 'public-read') do |progress|
         # Progress tracking logic here

--- a/app/models/concerns/project_storage.rb
+++ b/app/models/concerns/project_storage.rb
@@ -1,7 +1,7 @@
 require "securerandom"
 
 # Project-scoped S3 object-key prefixes. All projects share one bucket (default
-# "opendig"); each project's files live under <project>/artifacts/... (find images),
+# "opendig"); each project's files live under <project>/finds/... (find images),
 # <project>/daily_photos/... (official daily photos) and <project>/user_photos/...
 # (unofficial field photos taken on a paired device) so projects -- and the
 # official vs. user photo categories -- never collide. The project is the one
@@ -16,8 +16,8 @@ module ProjectStorage
     project
   end
 
-  def artifacts_prefix
-    "#{storage_project}/artifacts"
+  def finds_prefix
+    "#{storage_project}/finds"
   end
 
   def daily_photos_prefix

--- a/app/models/find.rb
+++ b/app/models/find.rb
@@ -24,7 +24,7 @@ class Find
   def self.get_image_keys(registration_number)
     Rails.cache.fetch("#{ProjectStorage.storage_project}/#{registration_number}_images", expires_in: 5.minutes) do
       bucket = Rails.application.config.s3_bucket
-      object_key = "#{ProjectStorage.artifacts_prefix}/#{registration_number}"
+      object_key = "#{ProjectStorage.finds_prefix}/#{registration_number}"
       bucket.objects(prefix: object_key).map(&:key)
     end
   end

--- a/app/services/device_configuration.rb
+++ b/app/services/device_configuration.rb
@@ -53,7 +53,7 @@ class DeviceConfiguration
   def storage_prefixes(key)
     CouchDB.with_project(key) do
       {
-        'artifacts_prefix' => ProjectStorage.artifacts_prefix,
+        'finds_prefix' => ProjectStorage.finds_prefix,
         'daily_photos_prefix' => ProjectStorage.daily_photos_prefix,
         'user_photos_prefix' => ProjectStorage.user_photos_prefix
       }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,10 @@ services:
       - minio
       - imgproxy
       - redis
-    command: sh -c "bin/rails server -b 0.0.0.0 -p 3000"
+    # Self-heal when the image predates a newly-added gem (e.g. after the Gemfile
+    # changes and the container is recreated): install only if something's missing,
+    # otherwise boot straight up.
+    command: sh -c "bundle check || bundle install; bin/rails server -b 0.0.0.0 -p 3000"
     platform: linux/amd64
   db:
     image: couchdb:latest

--- a/spec/models/project_storage_spec.rb
+++ b/spec/models/project_storage_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe ProjectStorage do
   it 'scopes S3 key prefixes under the current project' do
     CouchDB.current_project = 'balua'
 
-    expect(described_class.artifacts_prefix).to eq('balua/artifacts')
+    expect(described_class.finds_prefix).to eq('balua/finds')
     expect(described_class.daily_photos_prefix).to eq('balua/daily_photos')
     expect(described_class.user_photos_prefix).to eq('balua/user_photos')
   end

--- a/spec/services/device_configuration_spec.rb
+++ b/spec/services/device_configuration_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe DeviceConfiguration do
     expect(project['scopes']).to eq(['1'])
     expect(project['database']).to eq('opendig_test')
     expect(project['storage']).to eq(
-      'artifacts_prefix' => 'opendig/artifacts', 'daily_photos_prefix' => 'opendig/daily_photos',
+      'finds_prefix' => 'opendig/finds', 'daily_photos_prefix' => 'opendig/daily_photos',
       'user_photos_prefix' => 'opendig/user_photos'
     )
     expect(config['projects'].map { |p| p['key'] }).not_to include('balua') # not a member


### PR DESCRIPTION
Switches the find-photo storage category from `artifacts` to the neutral **`finds`** term — which also aligns the prefix with the existing `Find` model.

## Tree (after)
```
opendig/<project>/
  ├── finds/         ← was artifacts/  (find photos)
  ├── daily_photos/
  └── user_photos/
```

- `ProjectStorage.artifacts_prefix` → **`finds_prefix`** (`<project>/finds`); updated in `Find.get_image_keys` and `BulkUploadsController`.
- Device bundle storage key `artifacts_prefix` → **`finds_prefix`**.
- Find **report types** (`'Artifacts'`) are a separate concept (report category, not storage) and intentionally left unchanged.

## Data note
This changes the key prefix, so any objects already placed under `<project>/artifacts/` need to live under `<project>/finds/`. Since asset migration into the universal bucket is being done manually, place find photos under `finds/` directly — no separate migration step needed.

## Also
Dev container now self-heals (`bundle check || bundle install` on boot) so a recreate after a Gemfile change doesn't leave it missing gems (hit this with the recently-added bcrypt).

## Tests
208 examples, 0 failures; rubocop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)