### PR TITLE
Redesign areas page; remove placeholder Recent section

### DIFF
--- a/app/views/areas/_favorites.html.erb
+++ b/app/views/areas/_favorites.html.erb
@@ -1,22 +1,17 @@
 <%= turbo_frame_tag 'favorites' do %>
-  <h2 class="text-3xl">Favorites</h2>
-  <% if @favorites['areas'].blank? %>
-    <div class="p-6 bg-white">
-      <p class="text-gray-400">Click the star to favorite an area</p>
-    </div>
-  <% else %>
-    <div class="flex flex-row gap-4 h-[200px] min-w-[600px] overflow-x-auto mb-8">
-      <% @favorites['areas'].each do |area_key| %>
-        <div class="p-4 bg-white rounded border border-solid border-black-200 flex flex-col items-center flex-none w-[100rpx] h-[220px] overflow-hidden">
-          <img src="<%= asset_path("default.jpg") %>" alt="Default image" class="h-[100px] mb-3"/>
-          <p class="w-full text-center truncate">
-            <%= link_to "Area: #{area_key}", area_squares_path(area_key), class: "text-blue-600 hover:underline block", data: { turbo_frame: "_top" } %>
-          </p>
-          <%# shrink text by 1/4 %>
-          <p class="text-xs text-blue-600 hover:underline">square</p>
-          <p class="text-xs text-blue-600 hover:underline">Loci</p>
-        </div>
-      <% end %>
+  <% if @favorites['areas'].present? %>
+    <div class="mb-8">
+      <h2 class="font-serif text-2xl text-[#2a231b] mb-4 flex items-center gap-2">
+        <span class="text-yellow-400" aria-hidden="true">&starf;</span> Favorites
+      </h2>
+      <div class="flex flex-wrap gap-3">
+        <% @favorites['areas'].each do |area_key| %>
+          <%= link_to area_squares_path(area_key), data: { turbo_frame: "_top" },
+                      class: "inline-flex items-center gap-2 rounded-full border border-[#ddcfb4] bg-[#fbf6ec] px-4 py-2 font-serif text-[#2a231b] shadow-sm hover:border-[#c8a87f] hover:text-[#b1542b] transition-colors" do %>
+            <span class="text-yellow-400" aria-hidden="true">&starf;</span> Area <%= area_key %>
+          <% end %>
+        <% end %>
+      </div>
     </div>
   <% end %>
 <% end %>

--- a/app/views/areas/index.html.erb
+++ b/app/views/areas/index.html.erb
@@ -1,64 +1,54 @@
-<div class="flex">
-<div class="flex flex-col h-screen mt-10">
-  <div class="w-full px-4 mb-4">
-    <div class="flex items-center mb-4">
-      <h1 class="text-3xl">Areas</h1>
+<div class="container mx-auto px-2 py-8">
+  <div class="flex items-end flex-wrap gap-4 mb-8">
+    <div>
+      <h1 class="font-serif text-4xl text-[#2a231b]">Areas</h1>
+      <p class="text-[#6a5d4c] mt-1">Excavation areas in this dig &mdash; open one to browse its squares and loci.</p>
+    </div>
+    <% if current_user&.can_edit_dig_data? %>
       <div class="ml-auto">
-        <% if current_user&.can_edit_dig_data? %>
-          <%= link_to new_area_path do %>
-            <button type="button" class="inline-flex items-center px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded">
-              New area
-            </button>
-          <% end %>
+        <%= link_to new_area_path, class: "inline-flex items-center gap-2 rounded-full bg-[#b1542b] px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-[#8d3f1d] transition-colors" do %>
+          <span class="text-lg leading-none">+</span> New area
         <% end %>
       </div>
-    </div>
-
-    <%# let text overflow and set the width to be predetermined %>
-    <div class="p-6 bg-white rounded border border-solid border-black-200 overflow-y-auto h-[600px] w-[300px]">
-
-      <%# Is this breadcrumb needed on the first page? %>
-      <%# <nav aria-label="breadcrumb">
-        <ol class="breadcrumb">
-          <li class="breadcrumb-item active" aria-current="page">Home</li>
-        </ol>
-      </nav> %>
-      <% if @areas.empty? %>
-        <p class="text-gray-400">Create a new area to get started</p>
-      <% else %>
-        <% @areas.each do |area| %>
-          <% favorited = @favorites['areas']&.include?(area["key"]) %>
-          <div class="border-b border-gray-200 px-1 last:border-0 flex items-center justify-between">
-            <p class="mb-2"><%= link_to "Area: #{area["key"]}", area_squares_path(area["key"]), class: "text-blue-600 hover:underline" %></p>
-            <%= render 'favorite_toggle', area_key: area["key"], favorited: favorited %>
-          </div>  
-        <% end %>
-      <% end %>
-    </div>
-  </div>
-</div>
-
-<div class="flex flex-col gap-4 mr-auto ml-4 py-10 px-4 overflow-x-auto">
-  <%= render 'areas/favorites' %>
-
-  <h2 class="text-3xl">Recent</h2>
-  <div class="flex flex-row gap-4 h-[300px] min-w-[600px] overflow-x-auto mb-8">
-    <% if @areas.empty? %>
-      <div class="p-6 bg-white rounded border border-solid border-black-200">
-        <p class="text-gray-400">You have no recent areas yet.</p>
-      </div>
-    <% else %>
-      <% @areas.each do |area| %>
-      <div class="p-4 bg-white rounded border border-solid border-black-200 flex flex-col items-center flex-none w-[100rpx] h-[220px] overflow-hidden">
-        <img src="<%= asset_path("default.jpg") %>" alt="Default image" class="h-[100px] mb-3"/>
-        <p class="w-full text-center truncate">
-          <%= link_to "Area: #{area["key"]}", area_squares_path(area["key"]), class: "text-blue-600 hover:underline block" %>
-        </p>
-        <%# shrink text by 1/4 %>
-        <p class="text-xs text-blue-600 hover:underline">square</p>
-        <p class="text-xs text-blue-600 hover:underline">Loci</p>
-      </div>
-      <% end %>
     <% end %>
   </div>
+
+  <%= render 'areas/favorites' %>
+
+  <% if @areas.empty? %>
+    <div class="rounded-xl border border-dashed border-[#ddcfb4] bg-[#fbf6ec] p-12 text-center">
+      <p class="font-serif text-2xl text-[#2a231b] mb-1">No areas yet</p>
+      <p class="text-[#6a5d4c]">
+        <% if current_user&.can_edit_dig_data? %>
+          Create your first area to start recording squares and loci.
+        <% else %>
+          Areas will appear here once the team adds them.
+        <% end %>
+      </p>
+    </div>
+  <% else %>
+    <h2 class="font-serif text-2xl text-[#2a231b] mb-4">All areas</h2>
+    <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4">
+      <% @areas.each do |area| %>
+        <% favorited = @favorites['areas']&.include?(area["key"]) %>
+        <div class="group relative flex flex-col rounded-xl border border-[#ddcfb4] bg-[#fbf6ec] p-5 shadow-sm transition hover:-translate-y-0.5 hover:shadow-md hover:border-[#c8a87f]">
+          <div class="flex items-start justify-between gap-2 mb-3">
+            <span class="inline-flex h-11 w-11 items-center justify-center rounded-lg bg-[#efe3cf] text-[#b1542b] font-serif text-xl">
+              <%= area["key"].to_s.first(2).upcase %>
+            </span>
+            <%# Sits above the stretched card link so the star stays clickable. %>
+            <div class="relative z-10">
+              <%= render 'favorite_toggle', area_key: area["key"], favorited: favorited %>
+            </div>
+          </div>
+          <h3 class="font-serif text-2xl text-[#2a231b]">
+            <%= link_to "Area #{area["key"]}", area_squares_path(area["key"]),
+                        class: "transition-colors group-hover:text-[#b1542b] before:absolute before:inset-0",
+                        aria: { label: "Open area #{area["key"]}" } %>
+          </h3>
+          <span class="mt-3 text-sm font-medium text-[#b1542b]">View squares &rarr;</span>
+        </div>
+      <% end %>
+    </div>
+  <% end %>
 </div>

--- a/spec/views/areas/index.html.erb_spec.rb
+++ b/spec/views/areas/index.html.erb_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe 'areas/index', type: :view do
+  before do
+    assign(:areas, [{ 'key' => '24' }, { 'key' => '25' }])
+    assign(:favorites, { 'areas' => ['24'] })
+    without_partial_double_verification do
+      allow(view).to receive(:current_user).and_return(nil)
+    end
+  end
+
+  it 'lists each area linking through to its squares' do
+    render
+
+    expect(rendered).to include('Areas')
+    expect(rendered).to include('Area 24')
+    expect(rendered).to include('Area 25')
+    expect(rendered).to include(area_squares_path('24'))
+  end
+
+  it 'no longer renders the placeholder Recent section' do
+    render
+
+    expect(rendered).not_to include('Recent')
+    expect(rendered).not_to include('default.jpg') # the placeholder image is gone
+  end
+
+  it 'shows favorited areas in the Favorites frame' do
+    render
+
+    expect(rendered).to include('Favorites')
+  end
+end


### PR DESCRIPTION
## Removed
The **"Recent"** section on the areas page wasn't recency-based at all — it just re-rendered *every* area as `default.jpg` placeholder cards with hardcoded "square"/"Loci" labels. Gone, along with the dead empty `recent.html.erb`.

## Redesigned
Rebuilt the areas page in the established parchment/terracotta aesthetic (Spectral headings, `#fbf6ec` cards, `#b1542b` accents):
- **Responsive card grid** (2→5 cols) replacing the cramped fixed-width scroll list.
- Each card: an **initials badge**, the area name as a **stretched link** (whole card clickable), and a "View squares →" affordance. The **favorite star** is layered above the stretched link (z-10) so it stays independently clickable — no invalid form-inside-anchor nesting.
- **Favorites** restyled as clean star chips (no more placeholder images / fake labels), keeping the `favorites` turbo-frame so live toggling still works.
- **Empty state** is now a proper dashed card with role-aware copy.

Favoriting (turbo_stream replacing the star + the `favorites` frame) is unchanged and intact.

## Tests
New `areas/index` view spec: areas link through to squares, Favorites renders, and the placeholder Recent section / `default.jpg` are gone. 211 examples, 0 failures.

## Note
The **squares** page has the same placeholder Recent pattern — left it for now since this was scoped to areas. Happy to mirror this redesign there next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)