### PR TITLE
Redesign squares page to match areas

### DIFF
--- a/app/views/squares/_favorites.html.erb
+++ b/app/views/squares/_favorites.html.erb
@@ -1,23 +1,19 @@
 <%= turbo_frame_tag 'favorites' do %>
-  <h2 class="text-3xl">Favorites</h2>
-  <% if @favorites['squares'].blank? %>
-    <div class="p-6 bg-white">
-      <p class="text-gray-400">Click the star to favorite a square</p>
-    </div>
-  <% else %>
-    <div class="flex flex-row gap-4 h-[200px] min-w-[600px] overflow-x-auto mb-8">
-      <% @favorites['squares'].each do |resource_id| %>
-        <% area_key, square_key = resource_id.split('/', 2) %>
-        <div class="p-4 bg-white rounded border border-solid border-black-200 flex flex-col items-center flex-none w-[100rpx] h-[220px] overflow-hidden">
-          <img src="<%= asset_path("default.jpg") %>" alt="Default image" class="h-[100px] mb-3"/>
-          <p class="w-full text-center truncate">
-            <%= link_to "Square: #{square_key}", area_square_loci_path(area_key, square_key), class: "text-blue-600 hover:underline block", data: { turbo_frame: "_top" } %>
-          </p>
-          <%# shrink text by 1/4 %>
-          <p class="text-xs text-blue-600 hover:underline">square</p>
-          <p class="text-xs text-blue-600 hover:underline">Loci</p>
-        </div>
-      <% end %>
+  <% scoped = (@favorites['squares'] || []).select { |id| id.start_with?("#{@area}/") } %>
+  <% if scoped.present? %>
+    <div class="mb-8">
+      <h2 class="font-serif text-2xl text-[#2a231b] mb-4 flex items-center gap-2">
+        <span class="text-yellow-400" aria-hidden="true">&starf;</span> Favorites
+      </h2>
+      <div class="flex flex-wrap gap-3">
+        <% scoped.each do |resource_id| %>
+          <% area_key, square_key = resource_id.split('/', 2) %>
+          <%= link_to area_square_loci_path(area_key, square_key), data: { turbo_frame: "_top" },
+                      class: "inline-flex items-center gap-2 rounded-full border border-[#ddcfb4] bg-[#fbf6ec] px-4 py-2 font-serif text-[#2a231b] shadow-sm hover:border-[#c8a87f] hover:text-[#b1542b] transition-colors" do %>
+            <span class="text-yellow-400" aria-hidden="true">&starf;</span> Square <%= square_key %>
+          <% end %>
+        <% end %>
+      </div>
     </div>
   <% end %>
 <% end %>

--- a/app/views/squares/index.html.erb
+++ b/app/views/squares/index.html.erb
@@ -1,65 +1,59 @@
-<div class="flex">
-<div class="flex flex-col h-screen mt-10">
-  <div class="w-full px-4 mb-4">
-    <div class="flex items-center mb-4">
-      <h1 class="text-3xl">Square <%= @area %></h1>
+<div class="container mx-auto px-2 py-8">
+  <div class="flex items-end flex-wrap gap-4 mb-8">
+    <div>
+      <nav class="text-sm text-[#6a5d4c] mb-1">
+        <%= link_to "Areas", areas_path, class: "hover:text-[#b1542b]" %>
+        <span class="mx-1" aria-hidden="true">/</span>
+        <span class="text-[#2a231b]">Area <%= @area %></span>
+      </nav>
+      <h1 class="font-serif text-4xl text-[#2a231b]">Squares</h1>
+      <p class="text-[#6a5d4c] mt-1">Squares in Area <%= @area %> &mdash; open one to browse its loci.</p>
+    </div>
+    <% if current_user&.can_edit_dig_data?(area: @area) %>
       <div class="ml-auto">
-        <% if current_user&.can_edit_dig_data?(area: @area) %>
-          <%= link_to new_area_square_path(@area) do %>
-            <button type="button" class="inline-flex items-center px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded">
-              New Square
-            </button>
-          <% end %>
+        <%= link_to new_area_square_path(@area), class: "inline-flex items-center gap-2 rounded-full bg-[#b1542b] px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-[#8d3f1d] transition-colors" do %>
+          <span class="text-lg leading-none">+</span> New square
         <% end %>
       </div>
-    </div>
-
-  <%# let text overflow and set the width to be predetermined %>
-  <div class="p-6 bg-white rounded border border-solid border-black-200 overflow-y-auto h-[600px] w-[300px]">
-
-    <%# Breadcrumb navigation %>
-    <nav aria-label="breadcrumb" class="mb-4 text-center border-b border-gray-200 pb-4">
-      <ol class="breadcrumb">
-        <li class="breadcrumb-item"><%= link_to 'Home', root_path, class: "text-blue-600 hover:underline" %></li>
-        <li class="breadcrumb-item active" aria-current="page"><%= "Area #{@area}" %></li>
-      </ol>
-    </nav>
-
-    <% if @squares.empty? %>
-      <p class="text-gray-400">Create a new square to get started</p>
-    <% else %>
-      <% @squares.each do |square| %>
-      <% favorited = @favorites['squares']&.include?("#{@area}/#{square}") %>
-      <div class="border-b border-gray-200 px-1 last:border-0 flex items-center justify-between">
-        <p class="mb-2"><%= link_to "Square: #{square}", area_square_loci_path(@area, square), class: "text-blue-600 hover:underline" %></p>
-        <%= render 'favorite_toggle', square_key: square, favorited: favorited %>
-      </div>
-      <% end %>
     <% end %>
   </div>
-</div>
-</div>
 
-<div class="flex flex-col gap-4 mr-auto ml-4 py-10 px-4 overflow-x-auto">
   <%= render 'squares/favorites' %>
 
-  <h2 class="text-3xl">Recent</h2>
-  <div class="flex flex-row gap-4 h-[300px] min-w-[600px] overflow-x-auto mb-8">
-    <% if @squares.empty? %>
-      <div class="p-6 bg-white rounded border border-solid border-black-200">
-        <p class="text-gray-400">You have no recent squares yet.</p>
-      </div>
-    <% else %>
+  <% if @squares.empty? %>
+    <div class="rounded-xl border border-dashed border-[#ddcfb4] bg-[#fbf6ec] p-12 text-center">
+      <p class="font-serif text-2xl text-[#2a231b] mb-1">No squares yet</p>
+      <p class="text-[#6a5d4c]">
+        <% if current_user&.can_edit_dig_data?(area: @area) %>
+          Create your first square in this area to start recording loci.
+        <% else %>
+          Squares will appear here once the team adds them.
+        <% end %>
+      </p>
+    </div>
+  <% else %>
+    <h2 class="font-serif text-2xl text-[#2a231b] mb-4">All squares</h2>
+    <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4">
       <% @squares.each do |square| %>
-      <div class="p-4 bg-white rounded border border-solid border-black-200 flex flex-col items-center flex-none w-[100rpx] h-[220px] overflow-hidden">
-        <img src="<%= asset_path("default.jpg") %>" alt="Default image" class="h-[100px] mb-3"/>
-        <p class="w-full text-center truncate">
-          <%= link_to "Square: #{square}", area_square_loci_path(@area, square), class: "text-blue-600 hover:underline block" %>
-        </p>
-        <%# shrink text by 1/4 %>
-        <p class="text-xs text-blue-600 hover:underline">Loci</p>
-      </div>
+        <% favorited = @favorites['squares']&.include?("#{@area}/#{square}") %>
+        <div class="group relative flex flex-col rounded-xl border border-[#ddcfb4] bg-[#fbf6ec] p-5 shadow-sm transition hover:-translate-y-0.5 hover:shadow-md hover:border-[#c8a87f]">
+          <div class="flex items-start justify-between gap-2 mb-3">
+            <span class="inline-flex h-11 w-11 items-center justify-center rounded-lg bg-[#efe3cf] text-[#b1542b] font-serif text-xl">
+              <%= square.to_s.first(2).upcase %>
+            </span>
+            <%# Sits above the stretched card link so the star stays clickable. %>
+            <div class="relative z-10">
+              <%= render 'favorite_toggle', square_key: square, favorited: favorited %>
+            </div>
+          </div>
+          <h3 class="font-serif text-2xl text-[#2a231b]">
+            <%= link_to "Square #{square}", area_square_loci_path(@area, square),
+                        class: "transition-colors group-hover:text-[#b1542b] before:absolute before:inset-0",
+                        aria: { label: "Open square #{square}" } %>
+          </h3>
+          <span class="mt-3 text-sm font-medium text-[#b1542b]">View loci &rarr;</span>
+        </div>
       <% end %>
-    <% end %>
-  </div>
+    </div>
+  <% end %>
 </div>

--- a/spec/views/squares/index.html.erb_spec.rb
+++ b/spec/views/squares/index.html.erb_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe 'squares/index', type: :view do
+  before do
+    assign(:area, '24')
+    assign(:squares, %w[1 2])
+    assign(:favorites, { 'squares' => ['24/1'] })
+    without_partial_double_verification do
+      allow(view).to receive(:current_user).and_return(nil)
+    end
+  end
+
+  it 'lists each square linking through to its loci' do
+    render
+
+    expect(rendered).to include('Squares')
+    expect(rendered).to include('Square 1')
+    expect(rendered).to include('Square 2')
+    expect(rendered).to include(area_square_loci_path('24', '1'))
+  end
+
+  it 'no longer renders the placeholder Recent section' do
+    render
+
+    expect(rendered).not_to include('Recent')
+    expect(rendered).not_to include('default.jpg')
+  end
+
+  it 'shows area-scoped favorited squares in the Favorites frame' do
+    render
+
+    expect(rendered).to include('Favorites')
+  end
+end


### PR DESCRIPTION
Mirrors #43 on the squares page (one level deeper from areas), so the two are consistent.

## Removed
The same placeholder **"Recent"** strip — re-rendered every square as `default.jpg` cards with a hardcoded "Loci" label, not recency-based.

## Redesigned (matching areas)
- **Responsive card grid** in the parchment/terracotta aesthetic; each card has an initials badge, the square name as a **stretched link** to its loci, and a "View loci →" cue, with the **favorite star** layered above (z-10) so it stays clickable.
- **Favorites** restyled as star chips, now **scoped to the current area** (unambiguous on a per-area page, matching the controller's existing `@favorite_squares` intent — the old partial showed favorites from every area). Keeps the `favorites` turbo-frame so live toggling works.
- Added an **Areas breadcrumb** and fixed the heading (was literally "Square <area>" → now "Squares" with an "in Area N" subtitle).
- Proper empty state with role-aware copy.

## Tests
New `squares/index` view spec (links to loci, Favorites renders, Recent/`default.jpg` gone). 214 examples, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)