### PR TITLE
Fix image pipeline (signing, dev S3 config, fail-soft)

### DIFF
--- a/.envrc.example
+++ b/.envrc.example
@@ -1,25 +1,30 @@
-export AWS_ACCESS_KEY_ID= # retrieve from Minio
-export AWS_SECRET_ACCESS_KEY= # retrieve from Minio
-export EDIT_PASSWORD=editor
-export EDIT_USER=editor
-export IMGPROXY_KEY= # Hex-encoded string
-export IMGPROXY_SALT= # Hex-encoded string
-export IMGPROXY_URL=http://imgproxy:8080
+# Copy to .envrc and `direnv allow`. These feed the docker-compose containers, so
+# run docker compose from a shell where direnv has loaded them.
 
-# Single universal S3 bucket for all projects. Objects are keyed
-# <project>/artifacts/... and <project>/daily_photos/...
+# S3-compatible object store. In dev this is the local minio (see docker-compose);
+# its root credentials are admin / password unless you changed them. Both the app
+# and imgproxy read minio with these.
+export AWS_ACCESS_KEY_ID=admin
+export AWS_SECRET_ACCESS_KEY=password
+
+# Single universal bucket; objects are keyed <project>/finds/...,
+# <project>/daily_photos/... and <project>/user_photos/...
 export S3_BUCKET=opendig
 
+# imgproxy. The URL must be reachable FROM THE BROWSER (it ends up in <img src>),
+# so use localhost, NOT the internal docker hostname. Leave KEY/SALT blank in dev
+# to disable signature checking (the dev imgproxy accepts unsigned URLs); set them
+# in production, where the app signs URLs to match.
+export IMGPROXY_URL=http://localhost:8080
+export IMGPROXY_KEY= # hex-encoded; blank in dev
+export IMGPROXY_SALT= # hex-encoded; blank in dev
+
 # Public CouchDB URL handed to paired mobile devices for direct sync.
-# In production this must be a publicly reachable URL (e.g. https://db.opendig.org).
+# In production this must be a publicly reachable URL (e.g. https://couch.opendig.org).
 export COUCHDB_SYNC_URL=http://localhost:5984
 
-# Omniauth credentials. For more info, see `docs/Authentication.md`
+# Google OAuth (the only enabled provider). See docs/Authentication.md
 export GOOGLE_CLIENT_ID= # retrieve from Google Cloud Console
 export GOOGLE_CLIENT_SECRET= # retrieve from Google Cloud Console
-export MICROSOFT_CLIENT_ID= # retrieve from Microsoft Entra admin center
-export MICROSOFT_CLIENT_SECRET= # retrieve from Microsoft Entra admin center
-export GITHUB_CLIENT_ID= # retrieve from GitHub developer settings
-export GITHUB_CLIENT_SECRET= # retrieve from GitHub developer settings
 
 export RAILS_ENV=development

--- a/app/models/find.rb
+++ b/app/models/find.rb
@@ -22,11 +22,16 @@ class Find
   end
 
   def self.get_image_keys(registration_number)
+    bucket = Rails.application.config.try(:s3_bucket)
+    return [] if bucket.nil?
+
     Rails.cache.fetch("#{ProjectStorage.storage_project}/#{registration_number}_images", expires_in: 5.minutes) do
-      bucket = Rails.application.config.s3_bucket
       object_key = "#{ProjectStorage.finds_prefix}/#{registration_number}"
       bucket.objects(prefix: object_key).map(&:key)
     end
+  rescue StandardError => e
+    Rails.logger.warn("Find.get_image_keys failed for #{registration_number}: #{e.class}: #{e.message}")
+    []
   end
 
   def self.check_image(registration_number)
@@ -35,25 +40,27 @@ class Find
     end
   end
 
-  def self.get_presigned_urls(registration_number)
-    bucket = Rails.application.config.s3_bucket
+  NO_IMAGE_PLACEHOLDER = 'https://via.placeholder.com/250x250.png?text=No+Image'.freeze
 
-    if Find.can_have_image?(registration_number)
-      Rails.cache.fetch("#{ProjectStorage.storage_project}/#{registration_number}_presigned_urls", expires_in: 5.minutes) do
-        get_image_keys(registration_number).map { |key| bucket.object(key).presigned_url(:get) }
-      end
-    else
-      ['https://via.placeholder.com/250x250.png?text=No+Image']
+  def self.get_presigned_urls(registration_number)
+    bucket = Rails.application.config.try(:s3_bucket)
+    return [NO_IMAGE_PLACEHOLDER] if bucket.nil? || !Find.can_have_image?(registration_number)
+
+    Rails.cache.fetch("#{ProjectStorage.storage_project}/#{registration_number}_presigned_urls", expires_in: 5.minutes) do
+      get_image_keys(registration_number).map { |key| bucket.object(key).presigned_url(:get) }
     end
+  rescue StandardError => e
+    Rails.logger.warn("Find.get_presigned_urls failed for #{registration_number}: #{e.class}: #{e.message}")
+    [NO_IMAGE_PLACEHOLDER]
   end
 
   def self.url(key, style = :original)
+    bucket = Rails.application.config.try(:s3_bucket)
+    return Photo.placeholder_url(style) if bucket.nil?
+
     Rails.cache.fetch("#{key}_url_#{style}", expires_in: 1.hour) do
-      photo_style = Photo.styles(style)
-      builder = Imgproxy::Builder.new(
-        photo_style.transform_keys(&:to_sym)
-      )
-      builder.url_for("s3://#{Rails.application.config.s3_bucket.name}/#{key}")
+      builder = Imgproxy::Builder.new(Photo.styles(style).transform_keys(&:to_sym))
+      builder.url_for("s3://#{bucket.name}/#{key}")
     end
   end
 

--- a/app/models/photo.rb
+++ b/app/models/photo.rb
@@ -13,25 +13,33 @@ class Photo
     }[style]
   end
 
+  # Placeholder shown when an image is missing or the object store is unavailable
+  # (no bucket configured, bad credentials, network error) so a page never 500s
+  # over a photo.
+  def self.placeholder_url(style)
+    photo_style = styles(style) || {}
+    "https://placehold.jp/#{photo_style[:height] || 1000}x#{photo_style[:width] || 1000}.jpg?text=No+Image"
+  end
+
   def self.photo_exists?(number)
+    bucket = Rails.application.config.try(:s3_bucket)
+    return false if bucket.nil?
+
     Rails.cache.fetch "#{ProjectStorage.daily_photos_prefix}/#{number}_exists" do
-      bucket = Rails.application.config.s3_bucket
       bucket.object("#{ProjectStorage.daily_photos_prefix}/#{number}.JPG").exists?
     end
+  rescue StandardError => e
+    Rails.logger.warn("Photo.photo_exists? failed for #{number}: #{e.class}: #{e.message}")
+    false
   end
 
   def self.photo_url(number, style)
     Rails.cache.fetch "#{ProjectStorage.daily_photos_prefix}/photo_url_#{number}_#{style}" do
-      photo_style = styles(style)
       if photo_exists?(number)
-        builder = Imgproxy::Builder.new(
-          photo_style.transform_keys(&:to_sym)
-        )
+        builder = Imgproxy::Builder.new(styles(style).transform_keys(&:to_sym))
         builder.url_for("s3://#{Rails.application.config.s3_bucket.name}/#{ProjectStorage.daily_photos_prefix}/#{number}.JPG")
       else
-        height = photo_style[:height] || 1000
-        width = photo_style[:width] || 1000
-        "https://placehold.jp/#{height}x#{width}.jpg?text=No+Image"
+        placeholder_url(style)
       end
     end
   end
@@ -41,10 +49,12 @@ class Photo
   # number -> daily_photos mapping; the caller passes the full key recorded on
   # the locus, and the object is taken to exist (it's referenced in the record).
   def self.url_for_key(key, style)
+    bucket = Rails.application.config.try(:s3_bucket)
+    return placeholder_url(style) if bucket.nil?
+
     Rails.cache.fetch "photo_url_key_#{key}_#{style}" do
-      photo_style = styles(style)
-      builder = Imgproxy::Builder.new(photo_style.transform_keys(&:to_sym))
-      builder.url_for("s3://#{Rails.application.config.s3_bucket.name}/#{key}")
+      builder = Imgproxy::Builder.new(styles(style).transform_keys(&:to_sym))
+      builder.url_for("s3://#{bucket.name}/#{key}")
     end
   end
 

--- a/config/initializers/s3_bucket.rb
+++ b/config/initializers/s3_bucket.rb
@@ -2,32 +2,37 @@ require 'aws-sdk-core'
 require 'aws-sdk-s3'
 require 'imgproxy'
 
-if Rails.env.production?
-  # We use Wasabi (S3-compatible), so the endpoint and region must be explicit --
-  # never assume AWS. S3_URL is the Wasabi endpoint (e.g.
-  # https://s3.<region>.wasabisys.com); AWS_REGION must match it.
-  if ENV['S3_URL']
-    Aws.config.update(
-      endpoint: ENV['S3_URL'],
-      force_path_style: true
-    )
+# Configure the S3-compatible client wherever object storage is available:
+# production (Wasabi) and development (minio) both set S3_URL. The test env sets
+# neither and stubs config.s3_bucket. We use Wasabi/minio, never plain AWS, so
+# the endpoint and region are always explicit.
+#
+# Fail soft: Aws::S3::Resource.new validates credentials eagerly, so without them
+# it raises. A misconfigured/credential-less object store must NOT crash app boot
+# -- leave config.s3_bucket unset and let the image helpers fall back to a
+# placeholder (see Photo/Find).
+if ENV['S3_URL'].present? || Rails.env.production?
+  begin
+    Aws.config.update(endpoint: ENV['S3_URL'], force_path_style: true) if ENV['S3_URL'].present?
+    Aws.config.update(region: ENV.fetch('AWS_REGION', 'us-east-1'))
+
+    s3 = Aws::S3::Resource.new
+
+    # One universal bucket for all projects; project scoping happens in the object
+    # key (<project>/finds/..., <project>/daily_photos/..., <project>/user_photos/...).
+    Rails.application.config.s3_bucket = s3.bucket(ENV.fetch('S3_BUCKET', 'opendig'))
+  rescue StandardError => e
+    Rails.logger.warn("S3 object store not configured (#{e.class}: #{e.message}); image features disabled")
   end
-
-  Aws.config.update(
-    region: ENV.fetch('AWS_REGION', 'us-east-1')
-  )
-
-  s3 = Aws::S3::Resource.new
-
-  # One universal bucket for all projects; project scoping happens in the object
-  # key (<project>/artifacts/..., <project>/daily_photos/...). Dev and prod are
-  # separated by endpoint (minio vs. real S3), so the literal name is safe.
-  bucket_name = ENV.fetch('S3_BUCKET', 'opendig')
-  Rails.application.config.s3_bucket = s3.bucket(bucket_name)
 end
 
+# imgproxy must sign URLs with the same key/salt the imgproxy server enforces, or
+# the server rejects them. When they're absent (e.g. a dev imgproxy with signature
+# checking off) the gem emits unsigned /unsafe/ URLs, which that server accepts.
 Imgproxy.configure do |config|
   config.endpoint = ENV['IMGPROXY_URL']
+  config.key = ENV['IMGPROXY_KEY'] if ENV['IMGPROXY_KEY'].present?
+  config.salt = ENV['IMGPROXY_SALT'] if ENV['IMGPROXY_SALT'].present?
 end
 
 placeholder = ENV['PLACEHOLDER_URL'] || "https://placehold.jp/1000x1000.jpg?text=No+Image"


### PR DESCRIPTION
Investigated why images don't render. Found **three real bugs**, all fixed here:

### 1. imgproxy URLs were never signed
`Imgproxy.configure` set only `endpoint`, not `key`/`salt`. A production imgproxy with signing enabled (IMGPROXY_KEY/SALT set) **rejects unsigned URLs** → broken images. Now signs from the env when present; a dev imgproxy with no key still accepts the unsigned `/unsafe/` URLs.

### 2. `config.s3_bucket` only existed in production
The initializer was guarded by `if Rails.env.production?`, so in **dev every image helper hit `nil`** (`Photo.photo_url`, `Find.url`, `url_for_key`). Now configured wherever object storage is available (prod Wasabi, dev minio); test stubs it.

### 3. Object-store errors crashed the page / boot
`Aws::S3::Resource.new` validates credentials eagerly and **raised at boot** when creds were absent. S3 setup now **fails soft** (logs, leaves the bucket unset), and `Photo`/`Find` helpers fall back to the **placeholder** on a missing bucket or any S3 error instead of 500ing the page.

### Also
`.envrc.example` refreshed: minio creds (`admin`/`password`) documented, **`IMGPROXY_URL` → `http://localhost:8080`** (was the internal `imgproxy:8080` the browser can't resolve), dead GitHub/Microsoft/EDIT_USER vars removed, `finds` prefix.

## Not fixed by code (environment)
Local dev still needs a `.envrc` (none exists), the `opendig` bucket created in minio, and some images seeded — see PR discussion. Production needs the migrated objects present in Wasabi at `<project>/{finds,daily_photos,user_photos}/…`.

## Tests
214 examples, 0 failures; rubocop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)