### PR TITLE
Auto-refresh project list (no restart for new databases)

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -7,13 +7,30 @@ class Project
   # its data is migrated into a real project database.
   LEGACY_KEYS = %w[opendig].freeze
 
+  # How long a discovered database list is trusted before re-polling CouchDB.
+  # Short enough to pick up a newly-created project without a restart, long
+  # enough that _all_dbs load stays negligible. Override with PROJECT_DB_REFRESH
+  # (seconds; 0 = always re-poll).
+  CACHE_TTL_SECONDS = ENV.fetch('PROJECT_DB_REFRESH', 60).to_i
+
   class << self
-    # Project keys derived from the CouchDB databases for the current env,
-    # e.g. ["balua", "umayri"]. Memoized per process+env since the set of
-    # databases changes rarely (adding a project requires a restart to refresh).
+    # Project keys for the current env, e.g. ["balua", "umayri"], derived from the
+    # CouchDB databases. Cached with a short TTL and re-polled on expiry, so a
+    # newly created project database is picked up automatically -- no restart.
     def all(env: CouchDB.env)
-      @all ||= {}
-      @all[env] ||= keys_for(env)
+      @cache ||= {}
+      entry = @cache[env]
+      return entry[:keys] if entry && entry[:expires_at] > monotonic_now
+
+      fresh = keys_for(env)
+      if fresh
+        @cache[env] = { keys: fresh, expires_at: monotonic_now + CACHE_TTL_SECONDS }
+        fresh
+      else
+        # A failed poll keeps serving the last known list rather than dropping
+        # every project; only an empty initial cache yields [].
+        entry ? entry[:keys] : []
+      end
     end
 
     def exists?(key, env: CouchDB.env)
@@ -26,17 +43,27 @@ class Project
       "#{key}_#{env}"
     end
 
-    # Clear the memoized project list (e.g. after creating a new project db).
+    # Drop the cached list so the next call re-polls immediately (e.g. right
+    # after creating a project database).
     def reset_cache!
-      @all = {}
+      @cache = {}
     end
 
     private
 
+    def monotonic_now
+      Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    end
+
+    # Project keys for the env, or nil if the database list could not be fetched
+    # (so the caller can fall back to the last known list).
     def keys_for(env)
-      suffix       = "_#{env}"
-      users_db     = CouchDB.users_database_name(env)
-      database_names(env)
+      names = database_names(env)
+      return nil if names.nil?
+
+      suffix   = "_#{env}"
+      users_db = CouchDB.users_database_name(env)
+      names
         .reject { |name| name.start_with?('_') } # CouchDB system databases
         .select { |name| name.end_with?(suffix) }
         .map    { |name| name.delete_suffix(suffix) }
@@ -49,7 +76,7 @@ class Project
       CouchDB.server.databases
     rescue StandardError => e
       Rails.logger.error "Failed to list CouchDB databases for Project.all: #{e.class}: #{e.message}"
-      []
+      nil
     end
   end
 end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -23,6 +23,35 @@ RSpec.describe Project, type: :model do
       allow(CouchDB).to receive(:server).and_raise(StandardError)
       expect(described_class.all(env: 'production')).to eq([])
     end
+
+    it 're-polls for new databases after the TTL, with no restart' do
+      server = instance_double(CouchRest::Server)
+      allow(CouchDB).to receive_messages(users_database_name: 'opendig_users_production', server: server)
+      allow(described_class).to receive(:monotonic_now).and_return(0)
+
+      allow(server).to receive(:databases).and_return(%w[balua_production])
+      expect(described_class.all(env: 'production')).to eq(%w[balua])
+
+      # A new project db appears; within the TTL the cached list is still served.
+      allow(server).to receive(:databases).and_return(%w[balua_production umayri_production])
+      expect(described_class.all(env: 'production')).to eq(%w[balua])
+
+      # Once the TTL passes, the next call re-polls and picks the new one up.
+      allow(described_class).to receive(:monotonic_now).and_return(Project::CACHE_TTL_SECONDS + 1)
+      expect(described_class.all(env: 'production')).to eq(%w[balua umayri])
+    end
+
+    it 'keeps serving the last known list when a re-poll fails' do
+      server = instance_double(CouchRest::Server)
+      allow(CouchDB).to receive_messages(users_database_name: 'opendig_users_production', server: server)
+      allow(described_class).to receive(:monotonic_now).and_return(0)
+      allow(server).to receive(:databases).and_return(%w[balua_production])
+      expect(described_class.all(env: 'production')).to eq(%w[balua])
+
+      allow(described_class).to receive(:monotonic_now).and_return(Project::CACHE_TTL_SECONDS + 1)
+      allow(server).to receive(:databases).and_raise(StandardError)
+      expect(described_class.all(env: 'production')).to eq(%w[balua]) # not []
+    end
   end
 
   describe '.exists?' do


### PR DESCRIPTION
## Why
A new dig is created by adding a CouchDB database (`<key>_production`). But `Project.all` memoized the database list for the entire process lifetime, so a new project was invisible until the app was **restarted**.

## Fix
Replace the permanent memo with a **short TTL** (default **60s**, override via `PROJECT_DB_REFRESH` env; `0` = always re-poll). The list re-polls `_all_dbs` once the TTL expires, so a newly created project database is discovered automatically — no restart. `main_db` is already lazy per-project, so discovery was the only gap.

## Also
More resilient: if a re-poll fails (CouchDB blip), it **keeps serving the last known list** instead of dropping every project to `[]` and 404'ing every subdomain.

## Notes
- Per-process polling (each replica refreshes independently) → at most a couple of `_all_dbs` calls/min across the fleet, negligible.
- `reset_cache!` still forces an immediate refresh (the `projects:create` rake task calls it), so a new project shows up instantly when created through the app.
- New projects still need their design docs installed to be queryable (the rake task does this) — this PR only fixes discovery.

## Tests
Added: re-polls after the TTL (picks up a new db mid-process); keeps the last known list when a re-poll fails. 216 examples, 0 failures; rubocop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)