### PR TITLE
Run OAuth login through the apex (single Google redirect URI)

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -21,7 +21,7 @@ class SessionsController < ApplicationController
 
   def create
     if user_signed_in?
-      redirect_to root_path, notice: 'Already logged in!'
+      redirect_to post_login_destination, allow_other_host: true, notice: 'Already logged in!'
       return
     end
 
@@ -30,7 +30,9 @@ class SessionsController < ApplicationController
     user.apply_pending_invitations! # grant any roles this email was invited to
     session[:user_id] = user.id
     greeting = user.name.blank? ? '!' : ". Welcome #{user.name}!"
-    redirect_to root_path, notice: "Logged in with #{user.email}" + greeting
+    # The handshake ran on the apex; send the user back to the subdomain they
+    # started on (the shared session cookie keeps them signed in there).
+    redirect_to post_login_destination, allow_other_host: true, notice: "Logged in with #{user.email}#{greeting}"
   end
 
   def destroy
@@ -41,5 +43,27 @@ class SessionsController < ApplicationController
   def failure
     flash[:error] = 'Authentication failed, please try again.'
     redirect_to root_path
+  end
+
+  private
+
+  # After an apex OAuth callback, return to the subdomain the user came from
+  # (OmniAuth stores the request's `origin` param as omniauth.origin). Only honor
+  # an origin on our own registrable domain -- never an arbitrary host -- to avoid
+  # an open redirect; otherwise fall back to the local root.
+  def post_login_destination
+    origin = request.env['omniauth.origin']
+    return root_path if origin.blank?
+
+    uri = begin
+      URI.parse(origin)
+    rescue URI::InvalidURIError
+      nil
+    end
+    return root_path unless uri&.host
+
+    registrable = request.domain
+    same_site = uri.host == registrable || uri.host.end_with?(".#{registrable}")
+    same_site ? origin : root_path
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,25 @@
 module ApplicationHelper
+  # Always begin the OAuth handshake on the apex domain (opendig.org), so the
+  # provider (Google) needs only one registered redirect URI instead of one per
+  # subdomain. The `origin` carries the user back to the subdomain they started
+  # on; the shared session cookie (see config/initializers/session_store.rb)
+  # keeps them logged in there.
+  def oauth_start_url(provider, origin: oauth_return_origin)
+    "#{oauth_apex_base}/auth/#{provider}?origin=#{CGI.escape(origin)}"
+  end
+
+  # Scheme + apex host (registrable domain), preserving a non-default port in dev.
+  def oauth_apex_base
+    host = request.domain.presence || request.host
+    host = "#{host}:#{request.port}" unless request.port == (request.ssl? ? 443 : 80)
+    "#{request.scheme}://#{host}"
+  end
+
+  # Where to send the user after login: the root of the host they're on now.
+  def oauth_return_origin
+    "#{request.scheme}://#{request.host_with_port}/"
+  end
+
   def stratigraphic_relationships
     DataDigger.stratigraphy_related_how
   end

--- a/app/views/sessions/login.html.erb
+++ b/app/views/sessions/login.html.erb
@@ -76,12 +76,12 @@
       <div class="divider">or continue with</div>
 
       <div class="providers">
-        <%= button_to auth_path("google_oauth2"), method: :post, class: "prov" do %>
+        <%= button_to oauth_start_url("google_oauth2"), method: :post, class: "prov" do %>
           <svg viewBox="0 0 24 24" fill="currentColor"><path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"/><path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"/><path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"/><path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"/></svg>
           Google
         <% end %>
         <% if Rails.env.development? %>
-          <%= button_to auth_path("developer"), method: :post, class: "prov dev" do %>
+          <%= button_to oauth_start_url("developer"), method: :post, class: "prov dev" do %>
             Developer (dev only)
           <% end %>
         <% end %>

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -49,6 +49,35 @@ RSpec.describe SessionsController, type: :controller do
     end
   end
 
+  describe "post-login redirect (apex OAuth callback -> originating subdomain)" do
+    let(:auth_hash) do
+      { 'uid' => users[:viewer].uid, 'provider' => users[:viewer].provider,
+        'info' => { 'name' => users[:viewer].name, 'email' => users[:viewer].email } }
+    end
+
+    before do
+      request.host = 'opendig.org'
+      request.env['omniauth.auth'] = auth_hash
+    end
+
+    it "returns the user to a subdomain origin on our registrable domain" do
+      request.env['omniauth.origin'] = 'https://balua.opendig.org/'
+      get :create, params: { provider: 'test_provider' }
+      expect(response).to redirect_to('https://balua.opendig.org/')
+    end
+
+    it "ignores a foreign origin (open-redirect guard) and falls back to root" do
+      request.env['omniauth.origin'] = 'https://evil.example.com/'
+      get :create, params: { provider: 'test_provider' }
+      expect(response).to redirect_to(controller.root_path)
+    end
+
+    it "falls back to root when no origin is present" do
+      get :create, params: { provider: 'test_provider' }
+      expect(response).to redirect_to(controller.root_path)
+    end
+  end
+
   describe "applying invitations on login" do
     after { Invitation.find('opendig', 'invited@example.com')&.revoke! }
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe ApplicationHelper, type: :helper do
+  describe '#oauth_start_url' do
+    it 'starts the handshake on the apex domain, carrying the current host as origin' do
+      request.host = 'balua.opendig.org'
+
+      url = helper.oauth_start_url('google_oauth2')
+
+      expect(url).to start_with('http://opendig.org/auth/google_oauth2?origin=')
+      expect(url).to include(CGI.escape('http://balua.opendig.org/'))
+    end
+
+    it 'preserves a non-default port (dev) and the registrable domain' do
+      request.host = 'balua.lvh.me'
+      request.env['HTTP_HOST'] = 'balua.lvh.me:3000'
+
+      expect(helper.oauth_start_url('developer')).to start_with('http://lvh.me:3000/auth/developer?origin=')
+    end
+  end
+end


### PR DESCRIPTION
## Problem
Logging in from a subdomain (`balua.opendig.org`) errors out: Google OAuth doesn't support a wildcard redirect URI (`*.opendig.org`), and registering every dig subdomain is unmanageable.

## Fix — start the handshake on the apex
- The login buttons now POST to **`<apex>/auth/<provider>`** (`opendig.org`) with the originating subdomain as the **`origin`** param (`ApplicationHelper#oauth_start_url`). So the only redirect URI Google ever sees is the single apex callback `https://opendig.org/auth/google_oauth2/callback`.
- After the callback runs on the apex, `SessionsController` redirects back to that `origin` — **validated to our own registrable domain** (`opendig.org`/subdomains) to avoid an open redirect, falling back to root otherwise.
- The **shared session cookie** (`domain: :all`, already configured) means the login set on the apex is valid on the subdomain, so the user lands back on `balua.opendig.org` already signed in.

Works in dev too (apex = `lvh.me:3000`, port preserved). Email/password login is unaffected (it's a local POST, no external redirect).

## Google Console
Only one Authorized redirect URI is needed: `https://opendig.org/auth/google_oauth2/callback` (plus `http://lvh.me:3000/auth/google_oauth2/callback` for dev if desired).

## Tests
- Helper: builds the apex URL with the current host as origin; preserves a dev port.
- Controller: returns to a subdomain origin on our domain; ignores a foreign origin (open-redirect guard); falls back to root with no origin.
All green; rubocop clean.

> Note: unrelated uncommitted work in the tree (projects/cover-photo feature) currently breaks `device_configuration` and `areas/index` specs — not part of this PR and not caused by it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)