### PR TITLE
Redesign the locus edit form (declutter + parchment theme)

### DIFF
--- a/app/views/loci/_descriptions_form.html.erb
+++ b/app/views/loci/_descriptions_form.html.erb
@@ -1,29 +1,27 @@
-<div class="row mb-3">
-  <div class="col">
-    <h1 class="text-2xl font-bold"><%= "#{@locus['locus_type']} Description" %></h1>
-  </div>
-</div>
+<h1><%= "#{@locus['locus_type']} Description" %></h1>
 <% description_type = @descriptions['description_types'][@locus['locus_type']] %>
-<% @descriptions[description_type].each do |description_section| %>
-  <details class="group mb-4 rounded-lg border border-slate-300 bg-white p-4 shadow-sm open:shadow-md">
-    <summary class="flex cursor-pointer list-none items-center justify-between gap-4 rounded-md text-xl font-bold text-slate-900 outline-none transition-colors hover:text-slate-700 focus-visible:ring-2 focus-visible:ring-slate-400 focus-visible:ring-offset-2 [&::-webkit-details-marker]:hidden [&::marker]:hidden">
-      <span><%= description_section[0] %></span>
-      <span class="flex h-7 w-7 items-center justify-center rounded-full border border-slate-300 text-slate-500 transition-transform group-open:rotate-180">
-        <svg viewBox="0 0 20 20" fill="currentColor" class="h-4 w-4" aria-hidden="true">
-          <path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 0 1 1.06.02L10 10.946l3.71-3.715a.75.75 0 1 1 1.06 1.06l-4.24 4.25a.75.75 0 0 1-1.06 0l-4.25-4.25a.75.75 0 0 1 .02-1.06Z" clip-rule="evenodd" />
-        </svg>
-      </span>
-    </summary>
-
-    <div class="mt-4 space-y-4">
-      <% description_section[1].each do |description_section_entry| %>
-        <div class="form-group row">
-          <label for="field" class="col-sm-12 col-form-label"><%= description_section_entry['label'] %></label>
-          <div class="col-sm-12">
-            <%= input_for(description_section_entry, @locus&.dig(description_type)&.dig(description_section_entry['key']), description_type) %>
+<% if description_type && @descriptions[description_type].present? %>
+  <p class="text-sm text-[#6a5d4c] mb-4">Expand a section to edit its fields.</p>
+  <% @descriptions[description_type].each do |description_section| %>
+    <details class="group">
+      <summary class="flex cursor-pointer items-center justify-between gap-4 font-serif text-lg font-semibold text-[#2a231b] hover:text-[#b1542b] [&::-webkit-details-marker]:hidden [&::marker]:hidden">
+        <span><%= description_section[0] %></span>
+        <span class="flex h-7 w-7 items-center justify-center rounded-full border border-[#ddcfb4] text-[#9c6b3f] transition-transform group-open:rotate-180">
+          <svg viewBox="0 0 20 20" fill="currentColor" class="h-4 w-4" aria-hidden="true">
+            <path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 0 1 1.06.02L10 10.946l3.71-3.715a.75.75 0 1 1 1.06 1.06l-4.24 4.25a.75.75 0 0 1-1.06 0l-4.25-4.25a.75.75 0 0 1 .02-1.06Z" clip-rule="evenodd" />
+          </svg>
+        </span>
+      </summary>
+      <div class="mt-4 space-y-4">
+        <% description_section[1].each do |entry| %>
+          <div class="form-group">
+            <label><%= entry['label'] %></label>
+            <%= input_for(entry, @locus&.dig(description_type)&.dig(entry['key']), description_type) %>
           </div>
-        </div>
-      <% end %>
-    </div>
-  </details>
+        <% end %>
+      </div>
+    </details>
+  <% end %>
+<% else %>
+  <p class="text-[#6a5d4c]">No description fields for this locus type.</p>
 <% end %>

--- a/app/views/loci/_form.html.erb
+++ b/app/views/loci/_form.html.erb
@@ -1,11 +1,12 @@
-<%= render 'general_form', locus_form: locus_form %>
-<%= render 'interpretation_form', locus_form: locus_form %>
-<%= render 'descriptions_form', locus_form: locus_form %>
-<%= render 'stratigraphy_form', locus_form: locus_form %>
-<%= render 'levels_form', locus_form: locus_form %>
-<%= render 'photos_form', locus_form: locus_form %>
-<%= render 'pails_form', locus_form: locus_form %>
+<% %w[general_form interpretation_form descriptions_form stratigraphy_form levels_form photos_form pails_form].each do |partial| %>
+  <section class="ls-section">
+    <%= render partial, locus_form: locus_form %>
+  </section>
+<% end %>
 
-<div class="fixed bottom-0 right-0 p-4 bg-white z-50 border-t border-gray-200">
-	<%= submit_tag 'Save', class: 'bg-blue-500 text-white border-none px-4 py-2 rounded cursor-pointer hover:bg-blue-600' %>
+<div class="sticky bottom-0 -mx-2 mt-2 flex justify-end gap-3 border-t border-[#ddcfb4] bg-[#fbf6ec]/95 px-4 py-3 backdrop-blur">
+  <%= link_to 'Cancel', area_square_locus_path(@area, @square, @locus_code),
+              class: 'inline-flex items-center rounded-full border border-[#ddcfb4] px-4 py-2 text-sm font-medium text-[#6a5d4c] hover:border-[#c8a87f] hover:text-[#b1542b]' %>
+  <%= submit_tag 'Save changes',
+                 class: 'inline-flex items-center rounded-full bg-[#b1542b] px-5 py-2 text-sm font-medium text-white shadow-sm hover:bg-[#8d3f1d] cursor-pointer border-0' %>
 </div>

--- a/app/views/loci/_general_form.html.erb
+++ b/app/views/loci/_general_form.html.erb
@@ -1,141 +1,75 @@
-<div class="flex flex-col">
-  <div class="flex flex-row items-center justify-between mb-5">
-    <h1 class="text-3xl font-bold">Editing Locus <%= @area %>.<%= @square %>.<%= @locus_code %></h1>
-    <div></div>
+<h1>General</h1>
+
+<h2 class="ls-sub">Identification</h2>
+<div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+  <div>
+    <label for="locus_area">Area</label>
+    <input type="text" readonly name="locus[area]" id="locus_area" value="<%= @area %>">
   </div>
-
-  <div class="flex flex-col mb-5">
-    <div class="flex flex-row mb-4">
-      <div class="flex flex-col">
-        <h2 class="text-2xl font-bold">Identification</h2>
-      </div>
-    </div>
-    <div class="form-group flex flex-row mb-2">
-      <label for="area" class="flex items-center justify-end w-1/6 p-2">Area</label>
-      <div class="flex items-center w-1/6">
-        <input type="text" readonly class="form-control" name="locus[area]" id="locus[area]" value="<%= @area %>">
-      </div>
-      <label for="square" class="flex items-center justify-end w-1/6 p-2">Square</label>
-      <div class="flex items-center w-1/6">
-        <input type="text" readonly class="form-control" name="locus[square]" id="locus[square]" value="<%= @square %>">
-      </div>
-      <label for="code" class="flex items-center justify-end w-1/6 p-2">Locus Code</label>
-      <div class="flex items-center w-1/6">
-        <input type="text" class="form-control" name="locus[code]" id="locus[code]" value="<%= @locus['code'] %>">
-      </div>
-    </div>
-    <div class="form-group flex flex-row mb-2">
-      <label for="locus_type" class="flex items-center justify-end w-1/6 p-2">Locus Type</label>
-      <div class="flex items-center w-1/6">
-        <input type="text" readonly class="form-control" name="locus[locus_type]" value="<%= @locus['locus_type'] %>">
-      </div>
-      <label for="supervisor" class="flex items-center justify-end w-1/6 p-2">Supervisor</label>
-      <div class="flex items-center w-1/2">
-        <input type="text" class="form-control" name="locus[supervisor]" value="<%= @locus['supervisor'] %>">
-      </div>
-    </div>
-    <div class="form-group flex flex-row mb-2">
-      <label for="start_date" class="flex items-center justify-end w-1/6 p-2">Start Date</label>
-      <div class="flex items-center w-1/6">
-        <%# calendar svg %>
-        <input type="text" id="start_date" class="form-control" name="locus[start_date]" value="<%= read_date @locus['start_date'] %>" style="background-image: url('data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 fill=%22none%22 viewBox=%220 0 24 24%22 stroke=%22%236b7280%22 stroke-width=%222%22%3E%3Cpath stroke-linecap=%22round%22 stroke-linejoin=%22round%22 d=%22M8 7V3m8 4V3M3 11h18M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z%22/%3E%3C/svg%3E'); background-repeat: no-repeat; background-position: right 0.5rem center; background-size: 1rem 1rem;">
-      </div>
-      <label for="end_date" class="flex items-center justify-end w-1/6 p-2">End Date</label>
-      <div class="flex items-center w-1/6">
-        <%# calendar svg %>
-        <input type="text" id="end_date" class="form-control" name="locus[end_date]" value="<%= read_date @locus['end_date'] %>" style="background-image: url('data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 fill=%22none%22 viewBox=%220 0 24 24%22 stroke=%22%236b7280%22 stroke-width=%222%22%3E%3Cpath stroke-linecap=%22round%22 stroke-linejoin=%22round%22 d=%22M8 7V3m8 4V3M3 11h18M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z%22/%3E%3C/svg%3E'); background-repeat: no-repeat; background-position: right 0.5rem center; background-size: 1rem 1rem;">
-      </div>
-    </div>
-
-    <div class="form-group flex flex-row mb-2">
-      <label for="designation" class="flex items-center justify-end w-1/6 p-2">Designation</label>
-      <div class="flex items-center w-5/6">
-        <textarea class="form-control" id="locus[designation]" name="locus[designation]" rows="5"><%= @locus['designation'] %></textarea>
-      </div>
-    </div>
+  <div>
+    <label for="locus_square">Square</label>
+    <input type="text" readonly name="locus[square]" id="locus_square" value="<%= @square %>">
   </div>
+  <div>
+    <label for="locus_code">Locus Code</label>
+    <input type="text" name="locus[code]" id="locus_code" value="<%= @locus['code'] %>">
+  </div>
+  <div>
+    <label for="locus_type">Locus Type</label>
+    <input type="text" readonly name="locus[locus_type]" id="locus_type" value="<%= @locus['locus_type'] %>">
+  </div>
+  <div class="sm:col-span-2">
+    <label for="locus_supervisor">Supervisor</label>
+    <input type="text" name="locus[supervisor]" id="locus_supervisor" value="<%= @locus['supervisor'] %>">
+  </div>
+  <div>
+    <label for="start_date">Start Date</label>
+    <input type="text" id="start_date" name="locus[start_date]" value="<%= read_date @locus['start_date'] %>" autocomplete="off">
+  </div>
+  <div>
+    <label for="end_date">End Date</label>
+    <input type="text" id="end_date" name="locus[end_date]" value="<%= read_date @locus['end_date'] %>" autocomplete="off">
+  </div>
+</div>
 
-  <div class="flex flex-col mb-5">
-    <div class="flex flex-row mb-4">
-      <div class="flex flex-col">
-        <h2 class="text-2xl font-bold">Rationale</h2>
-      </div>
-    </div>
-    <div class="form-group flex flex-row mb-2">
-      <label for="reason" class="flex items-center justify-end w-1/6 p-2">Reason</label>
-      <div class="flex items-center w-5/6">
-        <textarea class="form-control" id="locus[reason]" name="locus[reason]" rows="5"><%= @locus['reason'] %></textarea>
-      </div>
-    </div>
+<div class="mt-4">
+  <label for="locus_designation">Designation</label>
+  <textarea id="locus_designation" name="locus[designation]" rows="4"><%= @locus['designation'] %></textarea>
+</div>
 
-    <div class="form-group flex flex-row mb-2">
-      <label for="top_separation" class="flex items-center justify-end w-1/6 p-2">Top Separation</label>
-      <div class="flex items-center w-5/6">
-        <div class="form-check form-check-inline mr-6">
-          <input class="form-check-input" type="radio" name="locus[top_separation]" id="top_separation_very_clear" value="Very Clear" <%= 'checked' if @locus['top_separation'] == 'Very Clear' %>>
-          <label class="form-check-label" for="top_separation_very_clear">Very Clear</label>
-        </div>
-        <div class="form-check form-check-inline mr-6">
-          <input class="form-check-input" type="radio" name="locus[top_separation]" id="top_separation_clear" value="Clear" <%= 'checked' if @locus['top_separation'] == 'Clear' %>>
-          <label class="form-check-label" for="top_separation_clear">Clear</label>
-        </div>
-        <div class="form-check form-check-inline mr-6">
-          <input class="form-check-input" type="radio" name="locus[top_separation]" id="top_separation_average" value="Average" <%= 'checked' if @locus['top_separation'] == 'Average' %>>
-          <label class="form-check-label" for="top_separation_average">Average</label>
-        </div>
-        <div class="form-check form-check-inline mr-6">
-          <input class="form-check-input" type="radio" name="locus[top_separation]" id="top_separation_unclear" value="Unclear" <%= 'checked' if @locus['top_separation'] == 'Unclear' %>>
-          <label class="form-check-label" for="top_separation_unclear">Unclear</label>
-        </div>
-        <div class="form-check form-check-inline mr-6">
-          <input class="form-check-input" type="radio" name="locus[top_separation]" id="top_separation_very_unclear" value="Very Unclear" <%= 'checked' if @locus['top_separation'] == 'Very Unclear' %>>
-          <label class="form-check-label" for="top_separation_very_unclear">Very Unclear</label>
-        </div>
-        <div class="form-check form-check-inline mr-6">
-          <input class="form-check-input" type="radio" name="locus[top_separation]" id="top_separation_arbitrary" value="Arbitrary" <%= 'checked' if @locus['top_separation'] == 'Arbitrary' %>>
-          <label class="form-check-label" for="top_separation_arbitrary">Arbitrary</label>
-        </div>
-      </div>
-    </div>
+<h2 class="ls-sub">Rationale</h2>
+<div>
+  <label for="locus_reason">Reason</label>
+  <textarea id="locus_reason" name="locus[reason]" rows="4"><%= @locus['reason'] %></textarea>
+</div>
 
-    <div class="form-group flex flex-row mb-2">
-      <label for="bottom_separation" class="flex items-center justify-end w-1/6 p-2">Bottom Separation</label>
-      <div class="flex items-center w-5/6">
-        <div class="form-check form-check-inline mr-6">
-          <input class="form-check-input" type="radio" name="locus[bottom_separation]" id="bottom_separation_very_clear" value="Very Clear" <%= 'checked' if @locus['bottom_separation'] == 'Very Clear' %>>
-          <label class="form-check-label" for="bottom_separation_very_clear">Very Clear</label>
-        </div>
-        <div class="form-check form-check-inline mr-6">
-          <input class="form-check-input" type="radio" name="locus[bottom_separation]" id="bottom_separation_clear" value="Clear" <%= 'checked' if @locus['bottom_separation'] == 'Clear' %>>
-          <label class="form-check-label" for="bottom_separation_clear">Clear</label>
-        </div>
-        <div class="form-check form-check-inline mr-6">
-          <input class="form-check-input" type="radio" name="locus[bottom_separation]" id="bottom_separation_average" value="Average" <%= 'checked' if @locus['bottom_separation'] == 'Average'%>>
-          <label class="form-check-label" for="bottom_separation_average">Average</label>
-        </div>
-        <div class="form-check form-check-inline mr-6">
-          <input class="form-check-input" type="radio" name="locus[bottom_separation]" id="bottom_separation_unclear" value="Unclear" <%= 'checked' if @locus['bottom_separation'] == 'Unclear' %>>
-          <label class="form-check-label" for="bottom_separation_unclear">Unclear</label>
-        </div>
-        <div class="form-check form-check-inline mr-6">
-          <input class="form-check-input" type="radio" name="locus[bottom_separation]" id="bottom_separation_very_unclear" value="Very Unclear" <%= 'checked' if @locus['bottom_separation'] == 'Very Unclear' %>>
-          <label class="form-check-label" for="bottom_separation_very_unclear">Very Unclear</label>
-        </div>
-        <div class="form-check form-check-inline mr-6">
-          <input class="form-check-input" type="radio" name="locus[bottom_separation]" id="bottom_separation_arbitrary" value="Arbitrary" <%= 'checked' if @locus['bottom_separation'] == 'Arbitrary' %>>
-          <label class="form-check-label" for="bottom_separation_arbitrary">Arbitrary</label>
-        </div>
-      </div>
-    </div>
+<% separation_values = ['Very Clear', 'Clear', 'Average', 'Unclear', 'Very Unclear', 'Arbitrary'] %>
+<div class="mt-4">
+  <label>Top Separation</label>
+  <div class="ls-choices">
+    <% separation_values.each do |opt| %>
+      <label class="ls-choice">
+        <input type="radio" name="locus[top_separation]" value="<%= opt %>" <%= 'checked' if @locus['top_separation'] == opt %>>
+        <%= opt %>
+      </label>
+    <% end %>
+  </div>
+</div>
+<div class="mt-4">
+  <label>Bottom Separation</label>
+  <div class="ls-choices">
+    <% separation_values.each do |opt| %>
+      <label class="ls-choice">
+        <input type="radio" name="locus[bottom_separation]" value="<%= opt %>" <%= 'checked' if @locus['bottom_separation'] == opt %>>
+        <%= opt %>
+      </label>
+    <% end %>
   </div>
 </div>
 
 <script>
-  $( "#start_date" ).datepicker({
-    dateFormat: "dd M, yy"
-  });
-
-  $( "#end_date" ).datepicker({
-    dateFormat: "dd M, yy"
+  $(function () {
+    $("#start_date").datepicker({ dateFormat: "dd M, yy" });
+    $("#end_date").datepicker({ dateFormat: "dd M, yy" });
   });
 </script>

--- a/app/views/loci/_interpretation_form.erb
+++ b/app/views/loci/_interpretation_form.erb
@@ -1,29 +1,10 @@
-<div class="row mb-3">
-  <div class="col">
-    <h1 class="text-2xl font-bold"><%= "#{@locus['locus_type']} Description" %></h1>
-  </div>
-</div>
-<% description_type = @descriptions['description_types'][@locus['locus_type']] %>
-<% @descriptions[description_type].each do |description_section| %>
-  <details open class="group mb-4 rounded-lg border border-slate-300 bg-white p-4 shadow-sm open:shadow-md">
-    <summary class="flex cursor-pointer items-center justify-between gap-4 rounded-md text-xl font-bold text-slate-900 outline-none transition-colors hover:text-slate-500 focus-visible:ring-2 focus-visible:ring-slate-400 focus-visible:ring-offset-2 [&::-webkit-details-marker]:hidden [&::marker]:hidden">
-      <h2><%= description_section[0] %></h2>
-      <span class="flex h-7 w-7 items-center justify-center rounded-full border border-slate-300 text-slate-500 transition-transform group-open:rotate-180">
-        <svg viewBox="0 0 20 20" fill="currentColor" class="h-4 w-4" aria-hidden="true">
-          <path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 0 1 1.06.02L10 10.946l3.71-3.715a.75.75 0 1 1 1.06 1.06l-4.24 4.25a.75.75 0 0 1-1.06 0l-4.25-4.25a.75.75 0 0 1 .02-1.06Z" clip-rule="evenodd" />
-        </svg>
-      </span>
-    </summary>
-
-    <div class="mt-4 space-y-4">
-      <% description_section[1].each do |description_section_entry| %>
-        <div class="form-group row">
-          <label for="field" class="col-sm-12 col-form-label"><%= description_section_entry['label'] %></label>
-          <div class="col-sm-12">
-            <%= input_for(description_section_entry, @locus&.dig(description_type)&.dig(description_section_entry['key']), description_type) %>
-          </div>
-        </div>
-      <% end %>
+<h1>Interpretation</h1>
+<div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+  <% (@descriptions['interpretation'] || []).each do |entry| %>
+    <% next if entry['key'] == 'stratigraphy_remarks' # edited in the Stratigraphy section %>
+    <div>
+      <label for="locus_<%= entry['key'] %>"><%= entry['label'] %></label>
+      <%= text_field_tag "locus[#{entry['key']}]", @locus[entry['key']], id: "locus_#{entry['key']}", class: 'form-control' %>
     </div>
-  </details>
-<% end %>
+  <% end %>
+</div>

--- a/app/views/loci/edit.html.erb
+++ b/app/views/loci/edit.html.erb
@@ -1,23 +1,99 @@
-<div class="container">
-  <div class="flex flex-row items-center justify-between mb-4">
-    <h1 class="text-3xl font-bold">Editing Locus <%= @area %>.<%= @square %>.<%= @locus_code %></h1>
-    <div></div>
+<div class="container mx-auto max-w-4xl px-2 py-8">
+  <nav class="text-sm text-[#6a5d4c] mb-2">
+    <%= link_to "Home", root_path, class: "hover:text-[#b1542b]" %>
+    <span class="mx-1" aria-hidden="true">/</span>
+    <%= link_to "Area #{@area}", area_squares_path(@area), class: "hover:text-[#b1542b]" %>
+    <span class="mx-1" aria-hidden="true">/</span>
+    <%= link_to "Square #{@square}", area_square_loci_path(@area, @square), class: "hover:text-[#b1542b]" %>
+    <span class="mx-1" aria-hidden="true">/</span>
+    <%= link_to "Locus #{@area}.#{@square}.#{@locus_code}", area_square_locus_path(@area, @square, @locus_code), class: "hover:text-[#b1542b]" %>
+  </nav>
+  <h1 class="font-serif text-4xl text-[#2a231b] mb-6">Editing Locus <%= @area %>.<%= @square %>.<%= @locus_code %></h1>
+
+  <div class="locus-form">
+    <%= form_with(url: area_square_locus_path(@area, @square, @locus_code), method: 'patch', local: true) do |locus_form| %>
+      <%= render 'form', locus_form: locus_form %>
+    <% end %>
   </div>
-  <div class="flex mb-4">
-    <nav aria-label="breadcrumb">
-      <ol class="flex flex-row">
-        <li class="mr-2"><%= link_to 'Home', root_path, class: "text-blue-500" %></li>
-        <li class="mr-2"><%= link_to "Area #{@area}", area_squares_path(@area), class: "text-blue-500" %></li>
-        <li class="mr-2"><%= link_to "Square #{@square}", area_square_loci_path(@area, @square), class: "text-blue-500" %></li>
-        <li class="mr-2"><%= link_to "Locus #{@area}.#{@square}.#{@locus_code}", area_square_locus_path(@area, @square, @locus_code), class: "text-blue-500" %></li>
-        <li class="text-gray-500" aria-current="page">Editing Locus <%= @area %>.<%= @square %>.<%= @locus_code %></li>
-      </ol>
-    </nav>
-  </div>
+
+  <%= render 'shared/navigation_safety' %>
 </div>
 
-<%= form_with(url: area_square_locus_path(@area, @square, @locus_code), method: 'patch', local: true, class: "mb-4") do |locus_form| %>
-  <%= render 'form', locus_form: locus_form %>
-<% end %>
+<style>
+  /* Scoped form theme for the locus editor (parchment / terracotta). Themes the
+     legacy Bootstrap-flavoured markup (.form-control, .row, .col, .btn, ...) that
+     is otherwise unstyled, plus the new section structure, in one place. */
+  .locus-form { color: #2a231b; }
 
-<%= render 'shared/navigation_safety' %>
+  /* Section cards */
+  .locus-form .ls-section {
+    background: #fbf6ec; border: 1px solid #ddcfb4; border-radius: 0.9rem;
+    padding: 1.5rem; margin-bottom: 1.5rem; box-shadow: 0 1px 2px rgba(42, 35, 27, 0.04);
+  }
+  .locus-form .ls-section h1 {
+    font-family: 'Spectral', serif; font-size: 1.55rem; font-weight: 600; color: #2a231b;
+    margin: 0 0 1.1rem; padding-bottom: 0.6rem; border-bottom: 1px solid #e7dcc4;
+  }
+  .locus-form .ls-sub {
+    font-family: 'Spectral', serif; font-size: 1.1rem; font-weight: 600;
+    color: #6a5d4c; margin: 1.4rem 0 0.8rem;
+  }
+  .locus-form .ls-sub:first-child { margin-top: 0; }
+
+  /* Labels */
+  .locus-form label, .locus-form .col-form-label {
+    display: block; font-weight: 500; color: #6a5d4c; font-size: 0.85rem; margin-bottom: 0.35rem;
+  }
+
+  /* Inputs */
+  .locus-form input[type="text"], .locus-form input[type="date"], .locus-form input[type="number"],
+  .locus-form input:not([type]), .locus-form textarea, .locus-form select, .locus-form .form-control {
+    display: block; width: 100%; box-sizing: border-box;
+    border: 1px solid #ddcfb4; border-radius: 0.55rem; background: #fff; color: #2a231b;
+    padding: 0.5rem 0.7rem; font-size: 0.92rem; line-height: 1.4;
+    transition: border-color 0.15s ease, box-shadow 0.15s ease;
+  }
+  .locus-form input:focus, .locus-form textarea:focus, .locus-form select:focus, .locus-form .form-control:focus {
+    outline: none; border-color: #9c6b3f; box-shadow: 0 0 0 3px rgba(177, 84, 43, 0.14);
+  }
+  .locus-form input[readonly] { background: #f1e9d8; color: #7a6c57; cursor: not-allowed; }
+  .locus-form textarea { min-height: 5.5rem; resize: vertical; }
+
+  /* Layout helpers (Bootstrap-compat) */
+  .locus-form .form-group { margin-bottom: 1rem; }
+  .locus-form .row, .locus-form .form-row { display: flex; flex-wrap: wrap; gap: 1rem; margin: 0; }
+  .locus-form .col { flex: 1 1 0; min-width: 0; }
+  .locus-form .col-sm-12 { flex: 0 0 100%; }
+  .locus-form .col-md-2 { flex: 1 1 7rem; }
+  .locus-form .col-md-3 { flex: 1 1 11rem; }
+  .locus-form .form-row .form-group, .locus-form .row .form-group { margin-bottom: 0; }
+
+  /* Repeatable rows become tidy inner cards */
+  .locus-form .stratigraphy-row, .locus-form .level-row, .locus-form .photo-row, .locus-form .pail-row {
+    display: flex; flex-wrap: wrap; gap: 1rem; align-items: flex-end;
+    background: #fff; border: 1px solid #e7dcc4; border-radius: 0.7rem; padding: 1rem; margin-bottom: 0.85rem;
+  }
+
+  /* Choice chips (radios) */
+  .locus-form .ls-choices { display: flex; flex-wrap: wrap; gap: 0.45rem; }
+  .locus-form .ls-choice {
+    display: inline-flex; align-items: center; gap: 0.4rem; margin: 0;
+    border: 1px solid #ddcfb4; background: #fff; border-radius: 9999px;
+    padding: 0.35rem 0.8rem; cursor: pointer; font-size: 0.85rem; font-weight: 500; color: #6a5d4c;
+  }
+  .locus-form .ls-choice:hover { border-color: #c8a87f; }
+  .locus-form .ls-choice input { width: auto; accent-color: #b1542b; margin: 0; }
+
+  /* Buttons (Bootstrap-compat) */
+  .locus-form .btn {
+    display: inline-flex; align-items: center; justify-content: center; border: none;
+    border-radius: 9999px; padding: 0.45rem 1rem; font-weight: 500; font-size: 0.85rem; cursor: pointer;
+  }
+  .locus-form .btn-danger { background: #fdecea; color: #9c2a1c; border: 1px solid #f0c5bd; }
+  .locus-form .btn-danger:hover { background: #f8d7d2; }
+  .locus-form .btn-sm { padding: 0.3rem 0.7rem; font-size: 0.8rem; }
+
+  /* Accordions (description) flush within the section card */
+  .locus-form details { border: 1px solid #e7dcc4; background: #fff; border-radius: 0.7rem; padding: 1rem; margin-bottom: 0.75rem; box-shadow: none; }
+  .locus-form details summary { color: #2a231b; }
+</style>


### PR DESCRIPTION
The locus edit form was crowded — it mixed **unstyled Bootstrap markup** (`.form-control`/`.row`/`.col`/`.btn`, none actually loaded → raw browser-default inputs) with a cramped `w-1/6` right-aligned layout.

- **Scoped `.locus-form` theme** restyles every input, label, repeatable row, button and accordion in the parchment/terracotta palette at once (all sections benefit without per-field rewrites).
- **General form** → responsive grid, labels above fields, **chip-style radio groups** (replacing 12 duplicated radio divs); dropped the duplicate heading + inline calendar-SVG noise.
- **Titled section cards** + **sticky themed Save/Cancel bar**.
- **Fixed `_interpretation_form`** — was a copy of `_descriptions_form` (rendered the description sections twice; interpretation was never editable). Now edits the real interpretation fields.
- **Descriptions collapse by default** to cut crowding.

Rendered the full edit template end-to-end (72 KB) — all sections present. `loci_controller_spec` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)