### PR TITLE
Theme the registrar find detail (show + edit)

### DIFF
--- a/app/views/loci/edit.html.erb
+++ b/app/views/loci/edit.html.erb
@@ -10,7 +10,7 @@
   </nav>
   <h1 class="font-serif text-4xl text-[#2a231b] mb-6">Editing Locus <%= @area %>.<%= @square %>.<%= @locus_code %></h1>
 
-  <div class="locus-form">
+  <div class="od-form">
     <%= form_with(url: area_square_locus_path(@area, @square, @locus_code), method: 'patch', local: true) do |locus_form| %>
       <%= render 'form', locus_form: locus_form %>
     <% end %>
@@ -19,81 +19,4 @@
   <%= render 'shared/navigation_safety' %>
 </div>
 
-<style>
-  /* Scoped form theme for the locus editor (parchment / terracotta). Themes the
-     legacy Bootstrap-flavoured markup (.form-control, .row, .col, .btn, ...) that
-     is otherwise unstyled, plus the new section structure, in one place. */
-  .locus-form { color: #2a231b; }
-
-  /* Section cards */
-  .locus-form .ls-section {
-    background: #fbf6ec; border: 1px solid #ddcfb4; border-radius: 0.9rem;
-    padding: 1.5rem; margin-bottom: 1.5rem; box-shadow: 0 1px 2px rgba(42, 35, 27, 0.04);
-  }
-  .locus-form .ls-section h1 {
-    font-family: 'Spectral', serif; font-size: 1.55rem; font-weight: 600; color: #2a231b;
-    margin: 0 0 1.1rem; padding-bottom: 0.6rem; border-bottom: 1px solid #e7dcc4;
-  }
-  .locus-form .ls-sub {
-    font-family: 'Spectral', serif; font-size: 1.1rem; font-weight: 600;
-    color: #6a5d4c; margin: 1.4rem 0 0.8rem;
-  }
-  .locus-form .ls-sub:first-child { margin-top: 0; }
-
-  /* Labels */
-  .locus-form label, .locus-form .col-form-label {
-    display: block; font-weight: 500; color: #6a5d4c; font-size: 0.85rem; margin-bottom: 0.35rem;
-  }
-
-  /* Inputs */
-  .locus-form input[type="text"], .locus-form input[type="date"], .locus-form input[type="number"],
-  .locus-form input:not([type]), .locus-form textarea, .locus-form select, .locus-form .form-control {
-    display: block; width: 100%; box-sizing: border-box;
-    border: 1px solid #ddcfb4; border-radius: 0.55rem; background: #fff; color: #2a231b;
-    padding: 0.5rem 0.7rem; font-size: 0.92rem; line-height: 1.4;
-    transition: border-color 0.15s ease, box-shadow 0.15s ease;
-  }
-  .locus-form input:focus, .locus-form textarea:focus, .locus-form select:focus, .locus-form .form-control:focus {
-    outline: none; border-color: #9c6b3f; box-shadow: 0 0 0 3px rgba(177, 84, 43, 0.14);
-  }
-  .locus-form input[readonly] { background: #f1e9d8; color: #7a6c57; cursor: not-allowed; }
-  .locus-form textarea { min-height: 5.5rem; resize: vertical; }
-
-  /* Layout helpers (Bootstrap-compat) */
-  .locus-form .form-group { margin-bottom: 1rem; }
-  .locus-form .row, .locus-form .form-row { display: flex; flex-wrap: wrap; gap: 1rem; margin: 0; }
-  .locus-form .col { flex: 1 1 0; min-width: 0; }
-  .locus-form .col-sm-12 { flex: 0 0 100%; }
-  .locus-form .col-md-2 { flex: 1 1 7rem; }
-  .locus-form .col-md-3 { flex: 1 1 11rem; }
-  .locus-form .form-row .form-group, .locus-form .row .form-group { margin-bottom: 0; }
-
-  /* Repeatable rows become tidy inner cards */
-  .locus-form .stratigraphy-row, .locus-form .level-row, .locus-form .photo-row, .locus-form .pail-row {
-    display: flex; flex-wrap: wrap; gap: 1rem; align-items: flex-end;
-    background: #fff; border: 1px solid #e7dcc4; border-radius: 0.7rem; padding: 1rem; margin-bottom: 0.85rem;
-  }
-
-  /* Choice chips (radios) */
-  .locus-form .ls-choices { display: flex; flex-wrap: wrap; gap: 0.45rem; }
-  .locus-form .ls-choice {
-    display: inline-flex; align-items: center; gap: 0.4rem; margin: 0;
-    border: 1px solid #ddcfb4; background: #fff; border-radius: 9999px;
-    padding: 0.35rem 0.8rem; cursor: pointer; font-size: 0.85rem; font-weight: 500; color: #6a5d4c;
-  }
-  .locus-form .ls-choice:hover { border-color: #c8a87f; }
-  .locus-form .ls-choice input { width: auto; accent-color: #b1542b; margin: 0; }
-
-  /* Buttons (Bootstrap-compat) */
-  .locus-form .btn {
-    display: inline-flex; align-items: center; justify-content: center; border: none;
-    border-radius: 9999px; padding: 0.45rem 1rem; font-weight: 500; font-size: 0.85rem; cursor: pointer;
-  }
-  .locus-form .btn-danger { background: #fdecea; color: #9c2a1c; border: 1px solid #f0c5bd; }
-  .locus-form .btn-danger:hover { background: #f8d7d2; }
-  .locus-form .btn-sm { padding: 0.3rem 0.7rem; font-size: 0.8rem; }
-
-  /* Accordions (description) flush within the section card */
-  .locus-form details { border: 1px solid #e7dcc4; background: #fff; border-radius: 0.7rem; padding: 1rem; margin-bottom: 0.75rem; box-shadow: none; }
-  .locus-form details summary { color: #2a231b; }
-</style>
+<%= render 'shared/edit_form_theme' %>

--- a/app/views/registrar/_form.html.erb
+++ b/app/views/registrar/_form.html.erb
@@ -1,4 +1,12 @@
-<%= render 'general_form', form: form %>
-<%= render 'registrars_form', form: form %>
+<% %w[general_form registrars_form].each do |partial| %>
+  <section class="ls-section">
+    <%= render partial, form: form %>
+  </section>
+<% end %>
 
-<%= submit_tag 'Save' %>
+<div class="sticky bottom-0 -mx-2 mt-2 flex justify-end gap-3 border-t border-[#ddcfb4] bg-[#fbf6ec]/95 px-4 py-3 backdrop-blur">
+  <%= link_to 'Cancel', registrar_path(id: @item_id, pail_id: @pail_id, item_number: @item_number, item_locus_code: @item_locus_code),
+              class: 'inline-flex items-center rounded-full border border-[#ddcfb4] px-4 py-2 text-sm font-medium text-[#6a5d4c] hover:border-[#c8a87f] hover:text-[#b1542b]' %>
+  <%= submit_tag 'Save changes',
+                 class: 'inline-flex items-center rounded-full bg-[#b1542b] px-5 py-2 text-sm font-medium text-white shadow-sm hover:bg-[#8d3f1d] cursor-pointer border-0' %>
+</div>

--- a/app/views/registrar/edit.html.erb
+++ b/app/views/registrar/edit.html.erb
@@ -1,27 +1,24 @@
-<div class="container mx-auto">
-  <div class="flex items-center mb-4">
-    <div class="w-10/12">
-      <h1 class="text-2xl font-bold">Field find or Sample #<%#= @find.field_number %></h1>
-    </div>
-    <div class="w-2/12">
-      <%= link_to "Back", registrar_path(id: @item_id, pail_id: @pail_id, item_number: @item_number, item_locus_code: @item_locus_code), class: "px-4 py-2 text-white bg-blue-500 hover:bg-blue-600 rounded-full float-right" %>
-    </div>
+<div class="container mx-auto max-w-4xl px-2 py-8">
+  <nav class="text-sm text-[#6a5d4c] mb-2">
+    <%= link_to 'Registrar', registrar_index_path, class: "hover:text-[#b1542b]" %>
+    <span class="mx-1" aria-hidden="true">/</span>
+    <%= link_to "Locus #{@area}.#{@square}.#{@locus_code}", area_square_locus_path(@area, @square, @locus_code), class: "hover:text-[#b1542b]" %>
+    <span class="mx-1" aria-hidden="true">/</span>
+    <span class="text-[#2a231b]">Pail <%= @pail_id %></span>
+  </nav>
+  <div class="flex flex-wrap items-end justify-between gap-4 mb-6">
+    <h1 class="font-serif text-4xl text-[#2a231b]">Editing Field Find #<%= @find['field_number'] %></h1>
+    <%= link_to "Back to find", registrar_path(id: @item_id, pail_id: @pail_id, item_number: @item_number, item_locus_code: @item_locus_code),
+                class: "inline-flex items-center rounded-full border border-[#ddcfb4] px-4 py-2 text-sm font-medium text-[#6a5d4c] hover:border-[#c8a87f] hover:text-[#b1542b]" %>
   </div>
-  <div class="flex mb-4">
-    <nav aria-label="breadcrumb">
-      <ol class="flex breadcrumb">
-        <li class="mr-2"><%= link_to 'Registrar Home', registrar_index_path, class: "text-blue-500 hover:underline" %></li>
-        <li class="mr-2"><%= link_to "Locus #{@area}.#{@square}.#{@locus_code}", area_square_locus_path(@area, @square, @locus_code), class: "text-blue-500 hover:underline" %></li>
-        <li>Pail Number <%= @pail_id %></li>
-      </ol>
-    </nav>
+
+  <div class="od-form">
+    <%= form_with(url: registrar_path(id: @item_id, pail_id: @pail_id, item_number: @item_number, item_locus_code: @item_locus_code), method: 'patch', local: true) do |form| %>
+      <%= render 'form', form: form %>
+    <% end %>
   </div>
+
+  <%= render 'shared/navigation_safety' %>
 </div>
 
-<%= form_with(url: registrar_path(id: @item_id, pail_id: @pail_id, item_number: @item_number, item_locus_code: @item_locus_code), method: 'patch', local: true) do |form| %>
-  <div class="container mx-auto">
-    <%= render 'form', form: form %>
-  </div>
-<% end %>
-
-<%= render 'shared/navigation_safety' %>
+<%= render 'shared/edit_form_theme' %>

--- a/app/views/registrar/show.html.erb
+++ b/app/views/registrar/show.html.erb
@@ -1,97 +1,64 @@
-<div class="container mx-auto">
-  <div class="flex items-center mb-4">
-    <div class="w-10/12">
-      <h1 class="text-2xl font-bold">Field Find <%= @find['field_number'] %></h1>
+<div class="container mx-auto max-w-5xl px-2 py-8">
+  <nav class="text-sm text-[#6a5d4c] mb-2">
+    <%= link_to 'Registrar', registrar_index_path, class: "hover:text-[#b1542b]" %>
+    <span class="mx-1" aria-hidden="true">/</span>
+    <%= link_to "Locus #{@area}.#{@square}.#{@locus_code}", area_square_locus_path(@area, @square, @locus_code), class: "hover:text-[#b1542b]" %>
+    <span class="mx-1" aria-hidden="true">/</span>
+    <span class="text-[#2a231b]">Pail <%= @pail_id %></span>
+  </nav>
+
+  <div class="flex flex-wrap items-end justify-between gap-4 mb-6">
+    <div>
+      <h1 class="font-serif text-4xl text-[#2a231b]">Field Find #<%= @find['field_number'] %></h1>
+      <p class="text-[#6a5d4c] mt-1">Locus <%= @area %>.<%= @square %>.<%= @locus_code %> &middot; Pail <%= @pail_id %></p>
     </div>
-    <div class="w-2/12">
-      <% if current_user&.can_edit_registrar? %>
-        <%= link_to "Edit", edit_registrar_path(id: @item_id, pail_id: @pail_id, item_number: @item_number, item_locus_code: @item_locus_code), class: "px-4 py-2 text-white bg-blue-500 hover:bg-blue-600 rounded-full float-right" %>
-      <% end %>
-    </div>
+    <% if current_user&.can_edit_registrar? %>
+      <%= link_to "Edit find", edit_registrar_path(id: @item_id, pail_id: @pail_id, item_number: @item_number, item_locus_code: @item_locus_code),
+                  class: "inline-flex items-center rounded-full bg-[#b1542b] px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-[#8d3f1d]" %>
+    <% end %>
   </div>
-  <div class="flex mb-4">
-    <nav aria-label="breadcrumb">
-      <ol class="flex breadcrumb">
-        <li class="mr-2"><%= link_to 'Registrar Home', registrar_index_path, class: "text-blue-500 hover:underline" %></li>
-        <li class="mr-2"><%= link_to "Locus #{@area}.#{@square}.#{@locus_code}", area_square_locus_path(@area, @square, @locus_code), class: "text-blue-500 hover:underline" %></li>
-        <li>Pail Number <%= @pail_id %></li>
-      </ol>
-    </nav>
-  </div>
-  <div class="flex mb-4">
-    <div class="w-8/12">
-      <h2 class="text-xl font-semibold">General Information</h2>
-      <% @descriptions['finds'].each do |item| %>
-        <div class="flex mb-2">
-          <div class="w-1/4">
-            <%= item["label"] %>
+
+  <div class="grid grid-cols-1 lg:grid-cols-3 gap-6 mb-6">
+    <div class="lg:col-span-2 rounded-xl border border-[#ddcfb4] bg-[#fbf6ec] p-6">
+      <h2 class="font-serif text-2xl text-[#2a231b] mb-4 pb-2 border-b border-[#e7dcc4]">General Information</h2>
+      <dl class="divide-y divide-[#e7dcc4]">
+        <% @descriptions['finds'].each do |item| %>
+          <div class="grid grid-cols-3 gap-3 py-2">
+            <dt class="text-sm font-medium text-[#6a5d4c]"><%= item["label"] %></dt>
+            <dd class="col-span-2 text-sm text-[#2a231b]"><%= output(@find.dig(item["key"]), item["type"]).presence || "—" %></dd>
           </div>
-          <div class="w-3/4">
-            <%= output(@find.dig(item["key"]), item["type"]) %>
-          </div>
-        </div>
-      <% end %>
+        <% end %>
+      </dl>
     </div>
-    <div class="w-4/12">
-      <% if Find.can_have_image?(@find.dig('registration_number')) %>
-      <div class="glide">
-        <div class="glide__track" data-glide-el="track">
-          <ul class="glide__slides">
 
-          </ul>
-        </div>
-      </div>
-
-
-      <div id="default-carousel" class="relative w-full" data-carousel="static">
-        <!-- Carousel wrapper -->
-        <div class="relative h-56 overflow-hidden rounded-lg md:h-96">
-            <% Find.get_image_keys(@find.dig('registration_number')).each do |key| %>
-            <div class="hidden duration-700 ease-in-out" data-carousel-item>
-                <%= image_tag(Find.url(key, :medium), class: 'absolute block w-full -translate-x-1/2 -translate-y-1/2 top-1/2 left-1/2') %>
-            </div>
+    <div class="rounded-xl border border-[#ddcfb4] bg-[#fbf6ec] p-4">
+      <h2 class="font-serif text-lg text-[#2a231b] mb-3">Images</h2>
+      <% image_keys = Find.can_have_image?(@find['registration_number']) ? Find.get_image_keys(@find['registration_number']) : [] %>
+      <% if image_keys.any? %>
+        <div class="space-y-3">
+          <% image_keys.each do |key| %>
+            <%= link_to Find.url(key, :original), target: "_blank", rel: "noopener", class: "block" do %>
+              <%= image_tag Find.url(key, :medium), class: "w-full rounded-lg border border-[#e7dcc4]", loading: "lazy", alt: "Find image" %>
             <% end %>
+          <% end %>
         </div>
-        <!-- Slider indicators -->
-        <div class="absolute z-30 flex space-x-3 -translate-x-1/2 bottom-5 left-1/2">
-            <button type="button" class="w-3 h-3 rounded-full" aria-current="true" aria-label="Slide 1" data-carousel-slide-to="0"></button>
-            <button type="button" class="w-3 h-3 rounded-full" aria-current="false" aria-label="Slide 2" data-carousel-slide-to="1"></button>
+      <% else %>
+        <div class="flex h-40 items-center justify-center rounded-lg border border-dashed border-[#ddcfb4] text-sm text-[#9c8e78]">
+          No images
         </div>
-        <!-- Slider controls -->
-        <button type="button" class="absolute top-0 left-0 z-30 flex items-center justify-center h-full px-4 cursor-pointer group focus:outline-none" data-carousel-prev>
-          <span class="inline-flex items-center justify-center w-8 h-8 rounded-full sm:w-10 sm:h-10 bg-black/30 dark:bg-gray-800/30 group-hover:bg-black/50 dark:group-hover:bg-gray-800/60 group-focus:ring-4 group-focus:ring-white dark:group-focus:ring-gray-800/70 group-focus:outline-none">
-            <svg aria-hidden="true" class="w-5 h-5 text-white sm:w-6 sm:h-6 dark:text-gray-800" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"></path>
-            </svg>
-            <span class="sr-only">Previous</span>
-          </span>
-        </button>
-        <button type="button" class="absolute top-0 right-0 z-30 flex items-center justify-center h-full px-4 cursor-pointer group focus:outline-none" data-carousel-next>
-          <span class="inline-flex items-center justify-center w-8 h-8 rounded-full sm:w-10 sm:h-10 bg-black/30 dark:bg-gray-800/30 group-hover:bg-black/50 dark:group-hover:bg-gray-800/60 group-focus:ring-4 group-focus:ring-white dark:group-focus:ring-gray-800/70 group-focus:outline-none">
-            <svg aria-hidden="true" class="w-5 h-5 text-white sm:w-6 sm:h-6 dark:text-gray-800" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
-            </svg>
-            <span class="sr-only">Next</span>
-          </span>
-        </button>
-    </div>
       <% end %>
     </div>
   </div>
-  <hr class="my-4">
-  <div class="flex mb-4">
-    <div class="w-full">
-      <h2 class="text-xl font-semibold">Detailed Information</h2>
+
+  <div class="rounded-xl border border-[#ddcfb4] bg-[#fbf6ec] p-6">
+    <h2 class="font-serif text-2xl text-[#2a231b] mb-4 pb-2 border-b border-[#e7dcc4]">Registration Details</h2>
+    <dl class="grid grid-cols-1 sm:grid-cols-2 sm:gap-x-10">
       <% @descriptions['registar_info'].each do |item| %>
-        <div class="flex mb-2">
-          <div class="w-1/4">
-            <%= item["label"] %>
-          </div>
-          <div class="w-3/4">
-            <%= output(@find.dig(item["key"]), item["type"]) %>
-          </div>
+        <div class="grid grid-cols-3 gap-3 py-2 border-b border-[#e7dcc4]">
+          <dt class="text-sm font-medium text-[#6a5d4c]"><%= item["label"] %></dt>
+          <dd class="col-span-2 text-sm text-[#2a231b]"><%= output(@find.dig(item["key"]), item["type"]).presence || "—" %></dd>
         </div>
       <% end %>
-    </div>
+    </dl>
   </div>
 </div>

--- a/app/views/shared/_edit_form_theme.html.erb
+++ b/app/views/shared/_edit_form_theme.html.erb
@@ -1,0 +1,79 @@
+<style>
+  /* Shared edit-form theme (parchment / terracotta). Scope a form region with
+     class="od-form"; it themes the legacy Bootstrap-flavoured markup
+     (.form-control, .row, .col, .btn, ...) which is otherwise unstyled, plus the
+     .ls-section / .ls-sub / .ls-choice helpers used by the redesigned forms. */
+  .od-form { color: #2a231b; }
+
+  /* Section cards */
+  .od-form .ls-section {
+    background: #fbf6ec; border: 1px solid #ddcfb4; border-radius: 0.9rem;
+    padding: 1.5rem; margin-bottom: 1.5rem; box-shadow: 0 1px 2px rgba(42, 35, 27, 0.04);
+  }
+  .od-form .ls-section h1 {
+    font-family: 'Spectral', serif; font-size: 1.55rem; font-weight: 600; color: #2a231b;
+    margin: 0 0 1.1rem; padding-bottom: 0.6rem; border-bottom: 1px solid #e7dcc4;
+  }
+  .od-form .ls-sub {
+    font-family: 'Spectral', serif; font-size: 1.1rem; font-weight: 600;
+    color: #6a5d4c; margin: 1.4rem 0 0.8rem;
+  }
+  .od-form .ls-sub:first-child { margin-top: 0; }
+
+  /* Labels */
+  .od-form label, .od-form .col-form-label {
+    display: block; font-weight: 500; color: #6a5d4c; font-size: 0.85rem; margin-bottom: 0.35rem;
+  }
+
+  /* Inputs */
+  .od-form input[type="text"], .od-form input[type="date"], .od-form input[type="number"],
+  .od-form input:not([type]), .od-form textarea, .od-form select, .od-form .form-control {
+    display: block; width: 100%; box-sizing: border-box;
+    border: 1px solid #ddcfb4; border-radius: 0.55rem; background: #fff; color: #2a231b;
+    padding: 0.5rem 0.7rem; font-size: 0.92rem; line-height: 1.4;
+    transition: border-color 0.15s ease, box-shadow 0.15s ease;
+  }
+  .od-form input:focus, .od-form textarea:focus, .od-form select:focus, .od-form .form-control:focus {
+    outline: none; border-color: #9c6b3f; box-shadow: 0 0 0 3px rgba(177, 84, 43, 0.14);
+  }
+  .od-form input[readonly] { background: #f1e9d8; color: #7a6c57; cursor: not-allowed; }
+  .od-form textarea { min-height: 5.5rem; resize: vertical; }
+
+  /* Layout helpers (Bootstrap-compat) */
+  .od-form .form-group { margin-bottom: 1rem; }
+  .od-form .row, .od-form .form-row { display: flex; flex-wrap: wrap; gap: 1rem; margin: 0; }
+  .od-form .col { flex: 1 1 0; min-width: 0; }
+  .od-form .col-sm-12 { flex: 0 0 100%; }
+  .od-form .col-md-2 { flex: 1 1 7rem; }
+  .od-form .col-md-3 { flex: 1 1 11rem; }
+  .od-form .form-row .form-group, .od-form .row .form-group { margin-bottom: 0; }
+
+  /* Repeatable rows become tidy inner cards */
+  .od-form .stratigraphy-row, .od-form .level-row, .od-form .photo-row, .od-form .pail-row {
+    display: flex; flex-wrap: wrap; gap: 1rem; align-items: flex-end;
+    background: #fff; border: 1px solid #e7dcc4; border-radius: 0.7rem; padding: 1rem; margin-bottom: 0.85rem;
+  }
+
+  /* Choice chips (radios) */
+  .od-form .ls-choices { display: flex; flex-wrap: wrap; gap: 0.45rem; }
+  .od-form .ls-choice {
+    display: inline-flex; align-items: center; gap: 0.4rem; margin: 0;
+    border: 1px solid #ddcfb4; background: #fff; border-radius: 9999px;
+    padding: 0.35rem 0.8rem; cursor: pointer; font-size: 0.85rem; font-weight: 500; color: #6a5d4c;
+  }
+  .od-form .ls-choice:hover { border-color: #c8a87f; }
+  .od-form .ls-choice input { width: auto; accent-color: #b1542b; margin: 0; }
+
+  /* Buttons (Bootstrap-compat) */
+  .od-form .btn {
+    display: inline-flex; align-items: center; justify-content: center; border: none;
+    border-radius: 9999px; padding: 0.45rem 1rem; font-weight: 500; font-size: 0.85rem; cursor: pointer;
+  }
+  .od-form .btn-danger { background: #fdecea; color: #9c2a1c; border: 1px solid #f0c5bd; }
+  .od-form .btn-danger:hover { background: #f8d7d2; }
+  .od-form .btn-sm { padding: 0.3rem 0.7rem; font-size: 0.8rem; }
+
+  /* Accordions (description) flush within the section card */
+  .od-form details { border: 1px solid #e7dcc4; background: #fff; border-radius: 0.7rem; padding: 1rem; margin-bottom: 0.75rem; box-shadow: none; }
+  .od-form details summary { color: #2a231b; }
+</style>


### PR DESCRIPTION
Carries the parchment/terracotta theme into the next click from the registrar pipeline — the find **show** and **edit** pages.

## Shared theme
Extracted the locus editor's form CSS into **`shared/_edit_form_theme`** (class `.od-form`) so it's reused, not duplicated. The locus editor now renders the shared partial (renamed `.locus-form` → `.od-form`); no visual change there.

## Registrar show
Rebuilt as parchment cards: a **General Information** definition list, an **Images** panel (themed gallery, or a clean *No images* placeholder), and a **Registration Details** card. Terracotta Edit button + breadcrumb. (Replaces the old `w-/12` columns, blue buttons, and the buggy hardcoded-2-indicator flowbite carousel.)

## Registrar edit
Parchment header/breadcrumb, the form wrapped in `.od-form` + the shared theme, **section cards**, and a **sticky Save / Cancel bar** — matching the locus editor. The field partials get themed by the shared CSS with no per-field edits.

## Verified
Rendered all three end-to-end (registrar show + edit, locus edit after the refactor). `registrar_controller_spec` + `loci_controller_spec`: 21 examples, 0 failures.

> Note: hit a pre-existing latent landmine while testing — the `Find` **model** collides with Ruby's stdlib `Find` module. In a real web request the model loads and the page works (as today), but if anything `require`s stdlib `find` into the web process, `Find.can_have_image?` would 500. Worth namespacing the model in a follow-up; out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)