### PR TITLE
Fix munsell colour (and nil-typed) fields not being editable

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -104,25 +104,24 @@ module ApplicationHelper
   end
 
   def input_for(form_definition_hash, value, description_type)
+    name = "locus[#{description_type}][#{form_definition_hash['key']}]"
     case form_definition_hash['type']
-    when 'picker'
-      if form_definition_hash['values'].is_a? Hash
-        select_tag "locus[#{description_type}][#{form_definition_hash['key']}]",
-                   options_for_select(@descriptions['lookups'][form_definition_hash['values']['from']], value),
-                   include_blank: true,
-                   class: 'form-control'
-      else
-        select_tag "locus[#{description_type}][#{form_definition_hash['key']}]",
-                   options_for_select(form_definition_hash['values'], value), include_blank: true, class: 'form-control'
-      end
-    when 'text_field'
-      text_field_tag "locus[#{description_type}][#{form_definition_hash['key']}]", value, class: 'form-control'
-    when 'date'
-      text_field_tag "locus[#{description_type}][#{form_definition_hash['key']}]", value, class: 'form-control'
+    # 'munsel_picker' (the Munsell colour list) is just a picker with inline values.
+    when 'picker', 'munsel_picker'
+      options = if form_definition_hash['values'].is_a?(Hash)
+                  @descriptions['lookups'][form_definition_hash['values']['from']]
+                else
+                  form_definition_hash['values']
+                end
+      select_tag name, options_for_select(options || [], value), include_blank: true, class: 'form-control'
     when 'checkbox'
-      check_box_tag "locus[#{description_type}][#{form_definition_hash['key']}]", true, false, class: 'form-control'
+      check_box_tag name, true, ActiveModel::Type::Boolean.new.cast(value), class: 'form-control'
     when 'text_area'
-      text_area_tag "locus[#{description_type}][#{form_definition_hash['key']}]", value, class: 'form-control'
+      text_area_tag name, value, class: 'form-control'
+    # text_field, date, and any missing/unknown type fall back to a text input so
+    # a field never silently disappears (was the case for nil-typed fields).
+    else
+      text_field_tag name, value, class: 'form-control'
     end
   end
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -18,4 +18,24 @@ RSpec.describe ApplicationHelper, type: :helper do
       expect(helper.oauth_start_url('developer')).to start_with('http://lvh.me:3000/auth/developer?origin=')
     end
   end
+
+  describe '#input_for' do
+    it 'renders an editable select for a munsel_picker (was unhandled -> blank)' do
+      field = { 'key' => 'munsel', 'type' => 'munsel_picker', 'values' => ['10YR 5/3', '2.5Y 4/2'] }
+
+      html = helper.input_for(field, '10YR 5/3', 'earth_description')
+
+      expect(html).to include('<select')
+      expect(html).to include('name="locus[earth_description][munsel]"')
+      expect(html).to include('<option selected="selected" value="10YR 5/3">10YR 5/3</option>')
+    end
+
+    it 'falls back to a text field for a missing/unknown type (was rendered nothing)' do
+      html = helper.input_for({ 'key' => 'foo', 'type' => nil }, 'bar', 'earth_description')
+
+      expect(html).to include('type="text"')
+      expect(html).to include('name="locus[earth_description][foo]"')
+      expect(html).to include('value="bar"')
+    end
+  end
 end


### PR DESCRIPTION
## Bug
On the locus edit form you could expand the **Color** section but couldn't edit the **Munsell** field. Its type is `munsel_picker`, but `input_for` only handled `picker`/`text_field`/`date`/`checkbox`/`text_area` — so it returned `nil` and rendered **nothing**. Five other fields with a missing (`nil`) type had the same symptom.

## Fix
- `munsel_picker` now renders as a picker (it carries inline `values`) → a `<select>` of the ~270 Munsell values, with the stored value selected.
- Any **unknown/missing type defaults to a text input**, so a field never silently disappears again.
- Bonus: `checkbox` now reflects the stored value instead of always rendering unchecked.

## Tests
Helper specs: `munsel_picker` → editable select with the value selected; nil type → text field. Verified by rendering the Earth-description form end-to-end. 4 examples, 0 failures; rubocop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)