### PR TITLE
Theme the user management page

### DIFF
--- a/app/views/admin/_invite_form.html.erb
+++ b/app/views/admin/_invite_form.html.erb
@@ -4,46 +4,47 @@
 
 <style>[x-cloak] { display: none !important; }</style>
 
+<% input_class = 'w-full rounded-md border border-[#ddcfb4] bg-white px-3 py-2 text-sm text-[#2a231b] focus:border-[#9c6b3f] focus:outline-none' %>
+<% label_class = 'block text-sm font-medium text-[#6a5d4c] mb-1' %>
+
 <div x-data="{ role: '<%= @invitation.role %>' }"
-     class="border border-gray-300 rounded p-4 mb-6 max-w-xl mx-auto">
-  <h2 class="text-xl font-bold mb-3">Invite a user</h2>
-  <p class="text-sm text-gray-500 mb-3">
+     class="max-w-xl mx-auto rounded-xl border border-[#ddcfb4] bg-[#fbf6ec] p-6 shadow-sm">
+  <h2 class="font-serif text-2xl text-[#2a231b] mb-1">Invite a user</h2>
+  <p class="text-sm text-[#6a5d4c] mb-4">
     The invited person gets this role the next time they sign in with this email address.
   </p>
 
   <%= form_with model: @invitation, url: invitations_path, method: :post, class: 'space-y-3' do |f| %>
     <div>
-      <%= f.label :email, 'Email', class: 'block text-sm text-gray-600 mb-1' %>
-      <%= f.email_field :email, required: true, placeholder: 'person@example.com',
-                        class: 'w-full px-2 py-1 border-2 rounded border-gray-300' %>
+      <%= f.label :email, 'Email', class: label_class %>
+      <%= f.email_field :email, required: true, placeholder: 'person@example.com', class: input_class %>
     </div>
 
     <div>
-      <%= f.label :role, 'Role', class: 'block text-sm text-gray-600 mb-1' %>
+      <%= f.label :role, 'Role', class: label_class %>
       <%= f.select :role,
                    options_for_select(assignable_roles.map { |role| [role.humanize, role] }, @invitation.role),
                    {},
-                   { 'x-model': 'role', class: 'w-full px-2 py-1 border-2 rounded border-gray-300' } %>
+                   { 'x-model': 'role', class: input_class } %>
     </div>
 
     <div x-show="role === 'area_supervisor'" x-cloak>
-      <%= f.label :scopes, 'Areas', class: 'block text-sm text-gray-600 mb-1' %>
+      <%= f.label :scopes, 'Areas', class: label_class %>
       <%= f.select :scopes, options_for_select(area_scopes),
                    { include_hidden: false },
                    { multiple: true, size: [area_scopes.size, 5].min,
-                     ':disabled': "role !== 'area_supervisor'",
-                     class: 'w-full px-2 py-2 border-2 rounded border-gray-300' } %>
+                     ':disabled': "role !== 'area_supervisor'", class: input_class } %>
     </div>
 
     <div x-show="role === 'square_supervisor'" x-cloak>
-      <%= f.label :scopes, 'Squares', class: 'block text-sm text-gray-600 mb-1' %>
+      <%= f.label :scopes, 'Squares', class: label_class %>
       <%= f.select :scopes, options_for_select(square_scopes),
                    { include_hidden: false },
                    { multiple: true, size: [square_scopes.size, 5].min,
-                     ':disabled': "role !== 'square_supervisor'",
-                     class: 'w-full px-2 py-2 border-2 rounded border-gray-300' } %>
+                     ':disabled': "role !== 'square_supervisor'", class: input_class } %>
     </div>
 
-    <%= f.submit 'Send invitation', class: 'px-4 py-2 bg-blue-500 text-white rounded cursor-pointer' %>
+    <%= f.submit 'Send invitation',
+                 class: 'inline-flex items-center rounded-full bg-[#b1542b] px-5 py-2 text-sm font-medium text-white shadow-sm hover:bg-[#8d3f1d] cursor-pointer border-0' %>
   <% end %>
 </div>

--- a/app/views/admin/_manage_users_role_form.html.erb
+++ b/app/views/admin/_manage_users_role_form.html.erb
@@ -1,55 +1,35 @@
+<% input_class = 'w-full rounded-md border border-[#ddcfb4] bg-white px-3 py-2 text-sm text-[#2a231b] focus:border-[#9c6b3f] focus:outline-none' %>
 <%= turbo_frame_tag "user_role_#{user.id_as_string}" do %>
-    <% if user == current_user %>
-        <div class="border border-gray-300 rounded p-2 w-full flex items-center justify-between">
-            <span><%= user.role.humanize %></span>
-            <span class="ml-2 text-sm text-gray-500">Cannot change own role</span>
-        </div>
-    <% else %>
-        <details class="group border border-gray-300 rounded p-2 w-full" <%= "open" if open %>>
-            <summary class="list-none cursor-pointer flex items-center justify-between">
-                <%= user.role.humanize %>
-                    <span class="ml-2 text-sm text-gray-500">
-                        <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 inline-block group-open:rotate-180" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
-                        </svg>
-                    </span>
-            </summary>
-            <hr class="my-2 border-gray-200" />
-            <%= form_with(
-                    model: user,
-                    url: admin_update_user_path(id: user.id_as_string),
-                    method: :patch,
-                    local: true,
-                    class: "gap-1 items-center"
-                ) do |f| %>
-                <div class="w-full text-center">
-                    <%= f.label :role, class: 'italic mb-2 ml-2 text-sm text-gray-500 text-center' %>
-                </div>
-                <% assignable_roles = User.roles.select { |role| current_user.can_assign_role?(role) } %>
-                <%= f.select :role,
-                    options_for_select(assignable_roles.map { |role| [role.humanize, role] }, selected: user.role),
-                    {},
-                    {
-                        disabled: user == current_user,
-                        class: "w-full px-2 py-1 border-2 rounded border-gray-300",
-                    }
-                %>
-                <% role_scopes = User.role_scopes_for(user.role, project: current_dig) %>
-                <% if role_scopes&.any? %>
-                    <div class="w-full text-center">
-                        <%= f.label :scopes, "Scopes (Ctrl to select multiple)", class: 'italic mb-2 ml-2 text-sm text-gray-500 text-center' %>
-                    </div>
-                    <%= f.select :scopes,
-                        options_for_select(role_scopes, selected: user.role_scopes),
-                        {},
-                        {
-                            disabled: user == current_user,
-                            class: "w-full px-2 py-2 border-2 rounded border-gray-300", multiple: true, size: [role_scopes.size, 5].min
-                        }
-                    %>
-                <% end %>
-                <%= f.submit "Update", disabled: user == current_user, class: "px-2 py-2 my-2 bg-blue-500 text-white rounded w-full" %>
-            <% end %>
-        </details>
-    <% end %>
+  <% if user == current_user %>
+    <div class="flex w-full items-center justify-between rounded-md border border-[#ddcfb4] bg-white px-3 py-2 text-sm">
+      <span class="font-medium text-[#2a231b]"><%= user.role.humanize %></span>
+      <span class="ml-2 text-xs text-[#9c8e78]">Cannot change own role</span>
+    </div>
+  <% else %>
+    <details class="group w-full rounded-md border border-[#ddcfb4] bg-white p-2" <%= "open" if open %>>
+      <summary class="flex cursor-pointer list-none items-center justify-between px-1 text-sm font-medium text-[#2a231b]">
+        <%= user.role.humanize %>
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 text-[#9c6b3f] transition-transform group-open:rotate-180" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+        </svg>
+      </summary>
+      <hr class="my-2 border-[#e7dcc4]" />
+      <%= form_with(model: user, url: admin_update_user_path(id: user.id_as_string), method: :patch, local: true, class: "space-y-2") do |f| %>
+        <%= f.label :role, class: 'block text-xs font-medium text-[#6a5d4c]' %>
+        <% assignable_roles = User.roles.select { |role| current_user.can_assign_role?(role) } %>
+        <%= f.select :role,
+                     options_for_select(assignable_roles.map { |role| [role.humanize, role] }, selected: user.role),
+                     {}, { disabled: user == current_user, class: input_class } %>
+        <% role_scopes = User.role_scopes_for(user.role, project: current_dig) %>
+        <% if role_scopes&.any? %>
+          <%= f.label :scopes, "Scopes (Ctrl to select multiple)", class: 'block text-xs font-medium text-[#6a5d4c]' %>
+          <%= f.select :scopes,
+                       options_for_select(role_scopes, selected: user.role_scopes),
+                       {}, { disabled: user == current_user, class: input_class, multiple: true, size: [role_scopes.size, 5].min } %>
+        <% end %>
+        <%= f.submit "Update", disabled: user == current_user,
+                     class: "w-full rounded-full bg-[#b1542b] px-4 py-2 text-sm font-medium text-white hover:bg-[#8d3f1d] cursor-pointer border-0" %>
+      <% end %>
+    </details>
+  <% end %>
 <% end %>

--- a/app/views/admin/manage_users.html.erb
+++ b/app/views/admin/manage_users.html.erb
@@ -1,79 +1,75 @@
-<div>
-<%# create an update notice %>
-  <h1 class="text-3xl font-bold mb-4 text-center">User Management</h1>
+<div class="container mx-auto max-w-4xl px-2 py-8">
+  <h1 class="font-serif text-4xl text-[#2a231b] mb-6 text-center">User Management</h1>
 
   <%= render 'admin/invite_form' %>
 
-  <div class="space-y-4">
-  <table class="w-full mt-6 border-collapse border border-gray-300">
-    <thead>
-      <tr class="bg-gray-200">
-        <th class="border border-gray-300 p-2 text-center">User</th>
-        <th class="border border-gray-300 p-2 text-center">Role</th>
-        <th class="border border-gray-300 p-2 text-center">Email</th>
-        <!-- TODO implement "view log"
-        <th class="border border-gray-300 p-2 text-center">Access Log</th>
-        -->
-      </tr>
-    </thead>
-    <tbody>
-      <% @users.each do |user| %>
-        <tr>
-          <td class="border border-gray-300 p-2 text-center w-1/3">
-            <span><%= user.name %></span>
-            <% if user == current_user %>
-                <span class="text-sm text-gray-500">(You)</span>
-            <% end %>
-          </td>
-          <td class="border border-gray-300 p-2 w-1/3">
-            <%= render partial: 'admin/manage_users_role_form', locals: { user: user, open: false } %>
-          </td>
-          <td class="border border-gray-300 p-2"><%= user.email %></td>
-          <!-- TODO implement "view log"
-          <td class="border border-gray-300 p-2">
-            <a href="#" class="text-blue-600 hover:underline">View Log</a>
-          </td>
-          -->
-        </tr>
-      <% end %>
-    </tbody>
-  </table>
-  </div>
-
-  <% if @invitations.present? %>
-    <div class="mt-10">
-      <h2 class="text-2xl font-bold mb-3">Pending Invitations</h2>
-      <table class="w-full border-collapse border border-gray-300">
-        <thead>
-          <tr class="bg-gray-200">
-            <th class="border border-gray-300 p-2 text-center">Email</th>
-            <th class="border border-gray-300 p-2 text-center">Role</th>
-            <th class="border border-gray-300 p-2 text-center">Invited By</th>
-            <th class="border border-gray-300 p-2 text-center">Action</th>
+  <div class="mt-8">
+    <h2 class="font-serif text-2xl text-[#2a231b] mb-3">Members</h2>
+    <div class="overflow-x-auto rounded-xl border border-[#ddcfb4]">
+      <table class="w-full text-sm">
+        <thead class="bg-[#f1e9d8] text-left text-[#6a5d4c]">
+          <tr>
+            <th class="px-4 py-3 font-medium">User</th>
+            <th class="px-4 py-3 font-medium">Role</th>
+            <th class="px-4 py-3 font-medium">Email</th>
           </tr>
         </thead>
-        <tbody>
-          <% @invitations.each do |invitation| %>
-            <tr>
-              <td class="border border-gray-300 p-2"><%= invitation.email %></td>
-              <td class="border border-gray-300 p-2 text-center">
-                <%= invitation.role.humanize %>
-                <% if invitation.scopes.present? %>
-                  <span class="text-sm text-gray-500">(<%= invitation.scopes.join(', ') %>)</span>
+        <tbody class="divide-y divide-[#e7dcc4] bg-white">
+          <% @users.each do |user| %>
+            <tr class="align-top hover:bg-[#fbf6ec]">
+              <td class="px-4 py-3">
+                <span class="text-[#2a231b]"><%= user.name %></span>
+                <% if user == current_user %>
+                  <span class="text-xs text-[#9c8e78]">(You)</span>
                 <% end %>
               </td>
-              <td class="border border-gray-300 p-2 text-center"><%= invitation.invited_by %></td>
-              <td class="border border-gray-300 p-2 text-center">
-                <%= button_to 'Revoke', revoke_invitation_path(email: invitation.email),
-                              method: :delete,
-                              form: { class: 'inline' },
-                              class: 'px-3 py-1 bg-red-500 text-white rounded',
-                              data: { confirm: 'Revoke this invitation?' } %>
+              <td class="px-4 py-3 w-1/3">
+                <%= render partial: 'admin/manage_users_role_form', locals: { user: user, open: false } %>
               </td>
+              <td class="px-4 py-3 text-[#6a5d4c]"><%= user.email %></td>
             </tr>
           <% end %>
         </tbody>
       </table>
+    </div>
+  </div>
+
+  <% if @invitations.present? %>
+    <div class="mt-10">
+      <h2 class="font-serif text-2xl text-[#2a231b] mb-3">Pending Invitations</h2>
+      <div class="overflow-x-auto rounded-xl border border-[#ddcfb4]">
+        <table class="w-full text-sm">
+          <thead class="bg-[#f1e9d8] text-left text-[#6a5d4c]">
+            <tr>
+              <th class="px-4 py-3 font-medium">Email</th>
+              <th class="px-4 py-3 font-medium">Role</th>
+              <th class="px-4 py-3 font-medium">Invited by</th>
+              <th class="px-4 py-3 font-medium text-right">Action</th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-[#e7dcc4] bg-white">
+            <% @invitations.each do |invitation| %>
+              <tr class="hover:bg-[#fbf6ec]">
+                <td class="px-4 py-3 text-[#2a231b]"><%= invitation.email %></td>
+                <td class="px-4 py-3 text-[#2a231b]">
+                  <%= invitation.role.humanize %>
+                  <% if invitation.scopes.present? %>
+                    <span class="text-xs text-[#9c8e78]">(<%= invitation.scopes.join(', ') %>)</span>
+                  <% end %>
+                </td>
+                <td class="px-4 py-3 text-[#6a5d4c]"><%= invitation.invited_by %></td>
+                <td class="px-4 py-3 text-right">
+                  <%= button_to 'Revoke', revoke_invitation_path(email: invitation.email),
+                                method: :delete,
+                                form: { class: 'inline' },
+                                class: 'rounded-full border border-[#f0c5bd] bg-[#fdecea] px-3 py-1 text-sm font-medium text-[#9c2a1c] hover:bg-[#f8d7d2] cursor-pointer',
+                                data: { confirm: 'Revoke this invitation?' } %>
+                </td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
     </div>
   <% end %>
 </div>

--- a/spec/controllers/admin_controller_spec.rb
+++ b/spec/controllers/admin_controller_spec.rb
@@ -25,6 +25,25 @@ RSpec.describe AdminController, type: :controller do
     end
   end
 
+  describe 'GET manage_users (rendered)' do
+    render_views
+
+    before do
+      session[:user_id] = users[:dig_director].id
+      # role_scopes_for stubbed to avoid the areas/squares views
+      allow(User).to receive_messages(find_all: [users[:dig_director], users[:viewer]], role_scopes_for: {})
+      allow(Invitation).to receive(:for_project).and_return([])
+    end
+
+    it 'renders the members table and invite form' do
+      get :manage_users
+      expect(response).to be_successful
+      expect(response.body).to include('User Management')
+      expect(response.body).to include('Invite a user')
+      expect(response.body).to include('Members')
+    end
+  end
+
   describe 'PATCH update_user' do
     let(:target) { users[:viewer] }
 


### PR DESCRIPTION
Carries the parchment/terracotta theme into the **User Management** (role admin) page (was gray/blue Bootstrap-ish).

- **Members** + **Pending Invitations** tables → themed (header band, hover, dividers, rounded border).
- **Invite a user** → parchment card with terracotta-focus inputs/select + submit; Alpine role→scope logic unchanged.
- **Per-user role editor** → themed select + terracotta Update; restyled "Cannot change own role".
- **Revoke** → subtle red pill.

Added a `render_views` spec exercising the page + layout + partials. 7 examples, 0 failures; rubocop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)