### PR TITLE
Keep users logged in until they sign out

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,8 +2,6 @@ class ApplicationController < ActionController::Base
   before_action :resolve_project
   before_action :set_db, :set_descriptions, :set_edit_mode
   before_action :check_editing_mode, only: %i[new edit create update destroy]
-  before_action :check_session_timeout
-  before_action :update_session_timestamp
 
   helper_method :current_user, :user_signed_in?, :require_authentication, :user_role?, :require_role,
                 :require_superuser, :require_dig_director, :require_area_supervisor, :require_square_supervisor,
@@ -106,20 +104,6 @@ class ApplicationController < ActionController::Base
   def favorited?(**categories)
     categories.all? do |category, resource_id|
       @favorites[category.to_s]&.include?(resource_id.to_s)
-    end
-  end
-
-  def update_session_timestamp
-    session[:last_seen] = Time.current
-  end
-
-  # 30-minute sliding expiration
-  def check_session_timeout
-    timeout_minutes = 30.minutes
-
-    if session[:last_seen].present? && (Time.current - Time.zone.parse(session[:last_seen].to_s)) > timeout_minutes
-      reset_session
-      flash[:alert] = "Your session has expired due to inactivity."
     end
   end
 

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -6,7 +6,13 @@
 # the request host -- "opendig.org" in production and "lvh.me" in development --
 # which are both two-label registrable domains. (This cookie tld_length is
 # independent of config.action_dispatch.tld_length, used for subdomain parsing.)
+# `expire_after` keeps people signed in across browser restarts (without it the
+# cookie is session-only and dies when the browser closes). It's a sliding window
+# refreshed on each request, so an active user effectively stays logged in until
+# they explicitly sign out; only ~a year of total inactivity ends the session.
+# There is no inactivity timeout -- this is a field tool, not a bank.
 Rails.application.config.session_store :cookie_store,
                                        key: '_opendig_session',
                                        domain: :all,
-                                       tld_length: 2
+                                       tld_length: 2,
+                                       expire_after: 1.year

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -175,45 +175,21 @@ RSpec.describe ApplicationController, type: :controller do
       end
     end
 
-    describe "check_session_timeout" do
+    describe "session persistence (no inactivity timeout)" do
       before do
         routes.draw do
           get 'index' => 'anonymous#index'
         end
       end
 
-      it "resets session and sets alert flash if session has expired" do
-        past_time = 31.minutes.ago
-        session[:last_seen] = past_time
+      it "keeps a long-idle session signed in (no timeout, no expiry flash)" do
+        session[:user_id] = 'someone'
+        session[:last_seen] = 100.days.ago # a stale value from before the timeout was removed
 
-        expect(session).to receive(:destroy)
         get :index
-        expect(flash[:alert]).to eq("Your session has expired due to inactivity.")
-      end
 
-      it "does not reset session if session is still valid" do
-        recent_time = 10.minutes.ago
-        session[:last_seen] = recent_time
-
-        expect(session).not_to receive(:destroy)
-        get :index
+        expect(session[:user_id]).to eq('someone')
         expect(flash[:alert]).to be_nil
-      end
-    end
-
-    describe "update_session_timestamp" do
-      before do
-        routes.draw do
-          get 'index' => 'anonymous#index'
-        end
-      end
-
-      it "updates session[:last_seen] to current time" do
-        travel_to Time.current do
-          get :index
-
-          expect(session[:last_seen]).to be_within(5.seconds).of(Time.current)
-        end
       end
     end
   end


### PR DESCRIPTION
Logging in often is a pain and this is a field tool, not a bank — so stop expiring sessions.

- **Removed the 30-minute inactivity timeout** (`check_session_timeout` / `update_session_timestamp` and their `before_action`s). No more "session expired due to inactivity."
- **Made the session cookie persistent**: `expire_after: 1.year` (without it the cookie was session-only and died on browser close). It's a sliding window refreshed each request, so an **active user stays signed in until they explicitly log out**; only ~a year of *total* inactivity ends it.

Logout (`reset_session`) still clears the cookie immediately.

Replaced the old timeout specs with one asserting a long-idle session stays signed in with no expiry flash. App boots with `expire_after = 1 year`. (The unrelated landing-page spec failure in my working tree is from separate uncommitted work, not this change — clean on CI.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)