### PR TITLE
Photo→locus tagging, project admin, and per-square pending photos

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -360,7 +360,7 @@ Rails/HelperInstanceVariable:
   Exclude:
     - 'app/helpers/application_helper.rb'
 
-# Offense count: 25
+# Offense count: 27
 Rails/I18nLocaleTexts:
   Exclude:
     - 'app/controllers/account_controller.rb'
@@ -370,6 +370,8 @@ Rails/I18nLocaleTexts:
     - 'app/controllers/invitations_controller.rb'
     - 'app/controllers/loci_controller.rb'
     - 'app/controllers/pails_controller.rb'
+    - 'app/controllers/photos_controller.rb'
+    - 'app/controllers/projects_controller.rb'
     - 'app/controllers/registrar_controller.rb'
     - 'app/controllers/sessions_controller.rb'
     - 'app/controllers/squares_controller.rb'

--- a/app/controllers/api/v1/photos_controller.rb
+++ b/app/controllers/api/v1/photos_controller.rb
@@ -13,9 +13,7 @@ module Api
         square = params[:square].to_s
 
         return render_unauthorized unless device_can_access?(project)
-        if area.blank? || square.blank?
-          return render(json: { error: 'area and square are required' }, status: :unprocessable_entity)
-        end
+        return render(json: { error: 'area and square are required' }, status: :unprocessable_entity) if area.blank? || square.blank?
 
         photos = CouchDB.with_project(project) do
           BulkPhoto.pending_for_square(area, square).map do |entry|

--- a/app/controllers/api/v1/photos_controller.rb
+++ b/app/controllers/api/v1/photos_controller.rb
@@ -1,0 +1,45 @@
+module Api
+  module V1
+    # Pending convention-named photos for a square, for the mobile app. Reuses
+    # the same bucket listing + matching as the web (BulkPhoto), scoped to the
+    # device user's project.
+    class PhotosController < Api::BaseController
+      before_action :authenticate_device!
+
+      # GET /api/v1/photos/pending?project=<key>&area=<a>&square=<s>
+      def pending
+        project = params[:project].to_s
+        area = params[:area].to_s
+        square = params[:square].to_s
+
+        return render_unauthorized unless device_can_access?(project)
+        if area.blank? || square.blank?
+          return render(json: { error: 'area and square are required' }, status: :unprocessable_entity)
+        end
+
+        photos = CouchDB.with_project(project) do
+          BulkPhoto.pending_for_square(area, square).map do |entry|
+            {
+              key: entry.key,
+              filename: entry.filename,
+              subject: entry.name.subject,
+              date: entry.name.date,
+              thumb_url: Photo.url_for_key(entry.key, :thumb),
+              url: Photo.url_for_key(entry.key, :medium)
+            }
+          end
+        end
+
+        render json: { photos: photos }
+      end
+
+      private
+
+      def device_can_access?(project)
+        return false if project.blank?
+
+        @current_user&.superuser? || @current_user&.roles&.key?(project)
+      end
+    end
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -18,6 +18,10 @@ class ApplicationController < ActionController::Base
     CouchDB.current_project = nil
 
     if key.blank?
+      # The apex host normally shows the landing page, but superuser project
+      # administration also lives at the apex (it spans all projects).
+      return if controller_name == 'projects'
+
       render 'shared/landing', layout: false
     elsif Project.exists?(key)
       @project = key

--- a/app/controllers/loci_controller.rb
+++ b/app/controllers/loci_controller.rb
@@ -9,6 +9,8 @@ class LociController < ApplicationController
                      { group: true, start_key: [@area, @square], end_key: [@area, @square, {}] })['rows'].map do |row|
       Locus.new(row['key'])
     end
+    # Convention-named photos in this square not yet linked to a locus.
+    @pending_photos = BulkPhoto.pending_for_square(@area, @square)
   end
 
   def search

--- a/app/controllers/photos_controller.rb
+++ b/app/controllers/photos_controller.rb
@@ -11,7 +11,7 @@ class PhotosController < ApplicationController
       candidates = entry.name.suggest_loci(loci)
       {
         entry: entry,
-        candidates: candidates.reject { |l| entry.linked_to.include?("#{l[:area]}.#{l[:square]}.#{l[:code]}") },
+        candidates: candidates.reject { |l| entry.linked_to.include?("#{l[:area]}.#{l[:square]}.#{l[:code]}") }
       }
     end
     @photos.sort_by! { |p| [p[:candidates].empty? ? 1 : 0, p[:entry].key] }
@@ -22,11 +22,9 @@ class PhotosController < ApplicationController
   # appending it to each locus doc's photos[].
   def associate
     key = params[:key].to_s
-    locus_ids = Array(params[:locus_ids]).reject(&:blank?)
+    locus_ids = Array(params[:locus_ids]).compact_blank
     return_to = params[:return_to].presence || photos_review_path
-    if key.blank? || locus_ids.empty?
-      return redirect_to(return_to, alert: 'Pick at least one locus for the photo.')
-    end
+    return redirect_to(return_to, alert: 'Pick at least one locus for the photo.') if key.blank? || locus_ids.empty?
 
     name = PhotoName.parse(File.basename(key))
     linked = []

--- a/app/controllers/photos_controller.rb
+++ b/app/controllers/photos_controller.rb
@@ -1,0 +1,65 @@
+class PhotosController < ApplicationController
+  before_action :require_registrar_read, only: [:review]
+  before_action :require_registrar_write, only: [:associate]
+
+  # Project-wide overview of convention-named photos and the loci they're
+  # linked to. (Per-square triage lives on the loci index page.)
+  def review
+    @bucket_configured = Rails.application.config.try(:s3_bucket).present?
+    loci = locus_index
+    @photos = BulkPhoto.all.map do |entry|
+      candidates = entry.name.suggest_loci(loci)
+      {
+        entry: entry,
+        candidates: candidates.reject { |l| entry.linked_to.include?("#{l[:area]}.#{l[:square]}.#{l[:code]}") },
+      }
+    end
+    @photos.sort_by! { |p| [p[:candidates].empty? ? 1 : 0, p[:entry].key] }
+    @unlinked_count = @photos.count { |p| p[:entry].pending? }
+  end
+
+  # Link an S3 photo to one or more loci (a photo can belong to many) by
+  # appending it to each locus doc's photos[].
+  def associate
+    key = params[:key].to_s
+    locus_ids = Array(params[:locus_ids]).reject(&:blank?)
+    return_to = params[:return_to].presence || photos_review_path
+    if key.blank? || locus_ids.empty?
+      return redirect_to(return_to, alert: 'Pick at least one locus for the photo.')
+    end
+
+    name = PhotoName.parse(File.basename(key))
+    linked = []
+    locus_ids.each do |id|
+      doc = @db.get(id)
+      doc['photos'] ||= []
+      next if doc['photos'].any? { |p| p['key'] == key }
+
+      doc['photos'] << {
+        'key' => key,
+        'filename' => File.basename(key),
+        'subject' => name.subject,
+        'date' => name.date,
+        'source' => 'bulk'
+      }
+      @db.save_doc(doc)
+      linked << "#{doc['area']}.#{doc['square']}.#{doc['code']}"
+    end
+
+    redirect_to return_to, notice: "Linked #{File.basename(key)} to #{linked.join(', ')}."
+  rescue StandardError => e
+    redirect_to return_to, alert: "Could not link photo: #{e.message}"
+  end
+
+  private
+
+  # All loci as {area, square, code, id} for suggestion matching.
+  def locus_index
+    @db.view('opendig/loci')['rows'].map do |row|
+      area, square, code, id = row['key']
+      { area: area, square: square, code: code, id: id }
+    end
+  rescue StandardError
+    []
+  end
+end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -18,6 +18,10 @@ class ProjectsController < ApplicationController
 
   def new; end
 
+  def edit
+    load_project
+  end
+
   def create
     key = Project.create!(
       params[:key],
@@ -41,10 +45,6 @@ class ProjectsController < ApplicationController
   rescue StandardError => e
     flash.now[:error] = "Could not create project: #{e.message}"
     render :new, status: :unprocessable_entity
-  end
-
-  def edit
-    load_project
   end
 
   def update

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -1,0 +1,89 @@
+class ProjectsController < ApplicationController
+  # Project management runs at the apex host (no project subdomain), so it must
+  # not require a current project database.
+  skip_before_action :set_db
+  skip_before_action :check_editing_mode
+  before_action :require_superuser
+
+  def index
+    @projects = Project.all.map do |key|
+      {
+        key: key,
+        name: Project.display_name(key),
+        description: Project.description(key),
+        cover_url: Project.cover_photo_url(key, :thumb)
+      }
+    end
+  end
+
+  def new; end
+
+  def create
+    key = Project.create!(
+      params[:key],
+      name: params[:name],
+      description: params[:description]
+    )
+    # Cover upload is best-effort: the project is already provisioned, so a
+    # failed/absent upload (e.g. S3 not configured in dev) must not roll it back.
+    if cover_param.present?
+      begin
+        Project.update_metadata(key, cover_photo: upload_cover(key))
+      rescue StandardError => e
+        flash[:warning] = "Project created, but the cover photo failed to upload: #{e.message}"
+      end
+    end
+    flash[:success] = "Project '#{key}' created."
+    redirect_to projects_path
+  rescue ArgumentError => e
+    flash.now[:error] = e.message
+    render :new, status: :unprocessable_entity
+  rescue StandardError => e
+    flash.now[:error] = "Could not create project: #{e.message}"
+    render :new, status: :unprocessable_entity
+  end
+
+  def edit
+    load_project
+  end
+
+  def update
+    key = params[:id]
+    cover_key = cover_param.present? ? upload_cover(key) : nil
+    Project.update_metadata(
+      key,
+      name: params[:name],
+      description: params[:description],
+      cover_photo: cover_key
+    )
+    flash[:success] = 'Project updated.'
+    redirect_to projects_path
+  rescue StandardError => e
+    flash.now[:error] = "Could not update project: #{e.message}"
+    load_project(key)
+    render :edit, status: :unprocessable_entity
+  end
+
+  private
+
+  def load_project(key = params[:id])
+    @key = key
+    @metadata = Project.metadata(key)
+    @cover_url = Project.cover_photo_url(key)
+  end
+
+  def cover_param
+    params[:cover]
+  end
+
+  # Upload the cover image to the shared bucket (public-read) and return its key.
+  def upload_cover(key)
+    bucket = Rails.application.config.try(:s3_bucket)
+    raise 'Object storage is not configured in this environment' if bucket.nil?
+
+    file = cover_param
+    object_key = Project.cover_photo_object_key(key, file.original_filename)
+    bucket.object(object_key).upload_file(file.tempfile.path, acl: 'public-read')
+    object_key
+  end
+end

--- a/app/models/bulk_photo.rb
+++ b/app/models/bulk_photo.rb
@@ -1,0 +1,67 @@
+# Convention-named photos sitting in the project's bucket (see PhotoName),
+# matched to loci by their filename. A photo can be linked to many loci; until
+# it's linked to at least one it is "pending" for its square.
+class BulkPhoto
+  Entry = Struct.new(:key, :name, :linked_to, keyword_init: true) do
+    def filename = File.basename(key)
+    def thumb_url = Photo.url_for_key(key, :thumb)
+    def pending? = linked_to.empty?
+  end
+
+  class << self
+    # Every convention-named photo in the bucket, with the loci it's already
+    # linked to. Legacy numbered photos ({number}.JPG) live in the same prefix
+    # but don't match the convention, so they're excluded here (they're handled
+    # by `rake photos:backfill_keys`, not the tagging UI).
+    def all
+      linked = linked_keys
+      bucket_keys.filter_map do |key|
+        name = PhotoName.parse(File.basename(key))
+        next unless name.valid?
+
+        Entry.new(key: key, name: name, linked_to: linked[key] || [])
+      end
+    end
+
+    # Photos whose filename area+square match the given square.
+    def for_square(area, square)
+      all.select do |e|
+        norm(e.name.area) == norm(area) && norm(e.name.square) == norm(square)
+      end
+    end
+
+    # Square photos not yet linked to any locus.
+    def pending_for_square(area, square)
+      for_square(area, square).select(&:pending?)
+    end
+
+    private
+
+    def bucket_keys
+      bucket = Rails.application.config.try(:s3_bucket)
+      return [] if bucket.nil?
+
+      bucket.objects(prefix: "#{ProjectStorage.daily_photos_prefix}/")
+            .map(&:key)
+            .reject { |k| k.end_with?('/') }
+    rescue StandardError => e
+      Rails.logger.error "Bulk photo list failed: #{e.class}: #{e.message}"
+      []
+    end
+
+    # s3 key => [locus codes it's linked to].
+    def linked_keys
+      CouchDB.main_db.view('opendig/photo_keys')['rows']
+             .each_with_object(Hash.new { |h, k| h[k] = [] }) do |row, h|
+        h[row['key']] << row['value'][0]
+      end
+    rescue StandardError
+      {}
+    end
+
+    def norm(value)
+      s = value.to_s.strip
+      s.match?(/\A\d+\z/) ? s.to_i.to_s : s.downcase
+    end
+  end
+end

--- a/app/models/concerns/project_storage.rb
+++ b/app/models/concerns/project_storage.rb
@@ -20,6 +20,9 @@ module ProjectStorage
     "#{storage_project}/finds"
   end
 
+  # All locus photos live here: legacy numbered photos ({number}.JPG) AND the
+  # new convention-named photos (B26.08.92.001.0621_Progress.JPG, see PhotoName),
+  # which are bulk-uploaded here and associated to loci by their full S3 key.
   def daily_photos_prefix
     "#{storage_project}/daily_photos"
   end

--- a/app/models/photo_name.rb
+++ b/app/models/photo_name.rb
@@ -1,0 +1,68 @@
+# Parses the excavation photo naming convention and suggests which locus a photo
+# belongs to, so bulk-uploaded photos can be auto-associated.
+#
+#   "B26.08.92.001.0621_Progress.JPG"
+#    └─────────────────────┴ Season.Area.Square.Sequence.Date_Subject(.ext)
+#
+# Season carries the 2-digit year (B26 -> 2026). Area+Square (and, when it
+# matches a locus code, Sequence) locate the locus. Anything that doesn't fit the
+# pattern is `valid? == false` and is left for manual association.
+class PhotoName
+  attr_reader :filename, :season, :area, :square, :sequence, :date, :subject, :ext
+
+  def self.parse(filename)
+    new(filename)
+  end
+
+  def initialize(filename)
+    @filename = filename.to_s
+    base = File.basename(@filename)
+    @ext = File.extname(base)
+    stem = @ext.empty? ? base : base[0...(base.length - @ext.length)]
+    core, subject = stem.split('_', 2)
+    @subject = subject
+    parts = core.to_s.split('.')
+    @valid = parts.length >= 5
+    @season, @area, @square, @sequence, @date = parts if @valid
+  end
+
+  def valid?
+    @valid
+  end
+
+  # Calendar year from the season code, e.g. "B26" -> 2026.
+  def season_year
+    digits = @season.to_s[/\d+/]
+    return nil unless digits
+
+    year = digits.to_i
+    year < 100 ? 2000 + year : year
+  end
+
+  # The locus this photo most likely belongs to: "area.square.sequence".
+  def locus_code
+    return nil unless valid?
+
+    "#{area}.#{square}.#{sequence}"
+  end
+
+  # Candidate loci for this photo: every locus in the photo's area+square. A
+  # photo can belong to many loci (Sequence is just a photo counter, not a locus
+  # code), so this is a candidate set to choose from, in the loci's natural
+  # order. `loci` is an array of hashes with :area, :square, :code (and :id).
+  def suggest_loci(loci)
+    return [] unless valid?
+
+    loci.select do |l|
+      norm(l[:area]) == norm(area) && norm(l[:square]) == norm(square)
+    end
+  end
+
+  private
+
+  # Compare codes numerically when possible so "08" == "8" and "001" == "1".
+  def norm(value)
+    s = value.to_s.strip
+    s.match?(/\A\d+\z/) ? s.to_i.to_s : s.downcase
+  end
+end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -59,7 +59,7 @@ class Project
     def metadata(key, env: CouchDB.env)
       return {} if key.blank? || !exists?(key, env: env)
 
-      CouchDB.main_db(key).get(META_DOC_ID)
+      CouchDB.main_db(key).get(META_DOC_ID) || {}
     rescue StandardError
       {}
     end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -49,6 +49,90 @@ class Project
       @cache = {}
     end
 
+    # --- project metadata (cover photo + description) ----------------------
+    #
+    # A project has no document of its own (it *is* a database), so optional
+    # presentation metadata lives in a single doc, `_id: "project"`, inside the
+    # project's CouchDB database.
+    META_DOC_ID = 'project'.freeze
+
+    def metadata(key, env: CouchDB.env)
+      return {} if key.blank? || !exists?(key, env: env)
+
+      CouchDB.main_db(key).get(META_DOC_ID)
+    rescue StandardError
+      {}
+    end
+
+    def display_name(key, env: CouchDB.env)
+      metadata(key, env: env)['name'].presence || key.to_s.humanize
+    end
+
+    def description(key, env: CouchDB.env)
+      metadata(key, env: env)['description'].presence
+    end
+
+    def cover_photo_key(key, env: CouchDB.env)
+      metadata(key, env: env)['cover_photo'].presence
+    end
+
+    # imgproxy URL for the project's cover photo, or nil when none is set.
+    def cover_photo_url(key, style = :medium, env: CouchDB.env)
+      cover = cover_photo_key(key, env: env)
+      return nil if cover.blank?
+
+      photo_style = Photo.styles(style)
+      Imgproxy::Builder.new(photo_style.transform_keys(&:to_sym))
+                       .url_for("s3://#{bucket_name}/#{cover}")
+    rescue StandardError
+      nil
+    end
+
+    # Provision a brand-new project: create its CouchDB database (which also
+    # pushes the design docs) and seed the metadata doc. Returns the key.
+    def create!(key, name: nil, description: nil, env: CouchDB.env)
+      key = normalize_key(key)
+      raise ArgumentError, 'A project key is required' if key.blank?
+      raise ArgumentError, "Project '#{key}' already exists" if exists?(key, env: env)
+
+      # Instantiating a CouchDB connection with an explicit db_name creates the
+      # database if missing and installs the design docs.
+      db = CouchDB.new(env: env, db_name: database_name(key, env: env))
+      db.save_doc(
+        '_id' => META_DOC_ID,
+        'type' => 'project',
+        'name' => name.presence || key.humanize,
+        'description' => description
+      )
+      reset_cache!
+      key
+    end
+
+    # Update presentation metadata for an existing project.
+    def update_metadata(key, name: nil, description: nil, cover_photo: nil, env: CouchDB.env)
+      db = CouchDB.main_db(key)
+      doc = (db.get(META_DOC_ID) rescue nil) || { '_id' => META_DOC_ID, 'type' => 'project' }
+      doc['name'] = name unless name.nil?
+      doc['description'] = description unless description.nil?
+      doc['cover_photo'] = cover_photo unless cover_photo.nil?
+      db.save_doc(doc)
+      doc
+    end
+
+    # Object key for a project's cover photo within the shared bucket.
+    def cover_photo_object_key(key, filename)
+      ext = File.extname(filename.to_s).downcase
+      "#{normalize_key(key)}/cover/cover#{ext.empty? ? '.jpg' : ext}"
+    end
+
+    def bucket_name
+      Rails.application.config.try(:s3_bucket)&.name || ENV.fetch('S3_BUCKET', 'opendig')
+    end
+
+    def normalize_key(key)
+      key.to_s.strip.downcase.gsub(/[^a-z0-9_]+/, '_').gsub(/\A_+|_+\z/, '')
+    end
+
     private
 
     def monotonic_now

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -110,8 +110,12 @@ class Project
 
     # Update presentation metadata for an existing project.
     def update_metadata(key, name: nil, description: nil, cover_photo: nil, env: CouchDB.env)
-      db = CouchDB.main_db(key)
-      doc = (db.get(META_DOC_ID) rescue nil) || { '_id' => META_DOC_ID, 'type' => 'project' }
+      db = CouchDB.new(env: env, db_name: database_name(key, env: env))
+      doc = begin
+        db.get(META_DOC_ID)
+      rescue StandardError
+        nil
+      end || { '_id' => META_DOC_ID, 'type' => 'project' }
       doc['name'] = name unless name.nil?
       doc['description'] = description unless description.nil?
       doc['cover_photo'] = cover_photo unless cover_photo.nil?

--- a/app/services/device_configuration.rb
+++ b/app/services/device_configuration.rb
@@ -37,7 +37,9 @@ class DeviceConfiguration
     project_keys.map do |key|
       {
         'key' => key,
-        'name' => key.humanize,
+        'name' => Project.display_name(key),
+        'description' => Project.description(key),
+        'cover_photo_url' => Project.cover_photo_url(key),
         # A superuser is superuser on every project, even ones with no explicit
         # roles entry; otherwise report the user's stored role for that project.
         'role' => superuser ? 'superuser' : @user.role_for(key),

--- a/app/views/areas/index.html.erb
+++ b/app/views/areas/index.html.erb
@@ -1,13 +1,13 @@
 <div class="container mx-auto px-2 py-8">
-  <% _cover = Project.cover_photo_url(current_dig) %>
-  <% _desc = Project.description(current_dig) %>
+  <% _cover = Project.cover_photo_url(CouchDB.current_project) %>
+  <% _desc = Project.description(CouchDB.current_project) %>
   <% if _cover.present? || _desc.present? %>
     <div class="mb-8 overflow-hidden rounded-2xl border border-[#ddcfb4] bg-[#fbf6ec]">
       <% if _cover.present? %>
         <img src="<%= _cover %>" alt="" class="h-48 w-full object-cover">
       <% end %>
       <div class="p-5">
-        <h1 class="font-serif text-3xl text-[#2a231b]"><%= Project.display_name(current_dig) %></h1>
+        <h1 class="font-serif text-3xl text-[#2a231b]"><%= Project.display_name(CouchDB.current_project) %></h1>
         <% if _desc.present? %>
           <p class="text-[#6a5d4c] mt-2 max-w-3xl"><%= _desc %></p>
         <% end %>

--- a/app/views/areas/index.html.erb
+++ b/app/views/areas/index.html.erb
@@ -1,4 +1,20 @@
 <div class="container mx-auto px-2 py-8">
+  <% _cover = Project.cover_photo_url(current_dig) %>
+  <% _desc = Project.description(current_dig) %>
+  <% if _cover.present? || _desc.present? %>
+    <div class="mb-8 overflow-hidden rounded-2xl border border-[#ddcfb4] bg-[#fbf6ec]">
+      <% if _cover.present? %>
+        <img src="<%= _cover %>" alt="" class="h-48 w-full object-cover">
+      <% end %>
+      <div class="p-5">
+        <h1 class="font-serif text-3xl text-[#2a231b]"><%= Project.display_name(current_dig) %></h1>
+        <% if _desc.present? %>
+          <p class="text-[#6a5d4c] mt-2 max-w-3xl"><%= _desc %></p>
+        <% end %>
+      </div>
+    </div>
+  <% end %>
+
   <div class="flex items-end flex-wrap gap-4 mb-8">
     <div>
       <h1 class="font-serif text-4xl text-[#2a231b]">Areas</h1>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -47,12 +47,22 @@
         <div class="hidden md:flex md:items-center md:gap-5">
           <ul class="flex items-center gap-5 text-[15px] font-medium text-[#6a5d4c]">
             <li><%= link_to "Home", root_path, class: "hover:text-[#b1542b]" %></li>
+            <% if current_dig.present? %>
+              <% _apex_port = request.optional_port ? ":#{request.optional_port}" : "" %>
+              <li><a class="hover:text-[#b1542b]" href="<%= "#{request.protocol}#{request.domain}#{_apex_port}/" %>">All digs</a></li>
+            <% end %>
             <% if user_signed_in? %>
+              <% if current_user.superuser? %>
+                <li><%= link_to("Projects", projects_path, class: "hover:text-[#b1542b]") %></li>
+              <% end %>
               <% if current_user.can_view_registrar? %>
                 <li><%= link_to("Registrar", registrar_index_path, class: "hover:text-[#b1542b]") %></li>
               <% end %>
               <% if current_user.can_edit_registrar? %>
                 <li><%= link_to("Bulk Upload", new_bulk_upload_path, class: "hover:text-[#b1542b]") %></li>
+              <% end %>
+              <% if current_user.can_edit_registrar? %>
+                <li><%= link_to("Photos", photos_review_path, class: "hover:text-[#b1542b]") %></li>
               <% end %>
               <% if current_user.can_manage_roles? %>
                 <li><%= link_to("Users", manage_users_admin_index_path, class: "hover:text-[#b1542b]") %></li>
@@ -111,6 +121,9 @@
             <% end %>
             <% if current_user.can_edit_registrar? %>
               <li><%= link_to("Bulk Upload", new_bulk_upload_path, class: "block rounded px-3 py-2 hover:bg-[#efe3cf] hover:text-[#b1542b]") %></li>
+            <% end %>
+            <% if current_user.can_edit_registrar? %>
+              <li><%= link_to("Photos", photos_review_path, class: "block rounded px-3 py-2 hover:bg-[#efe3cf] hover:text-[#b1542b]") %></li>
             <% end %>
             <% if current_user.can_manage_roles? %>
               <li><%= link_to("Users", manage_users_admin_index_path, class: "block rounded px-3 py-2 hover:bg-[#efe3cf] hover:text-[#b1542b]") %></li>

--- a/app/views/loci/_pending_photos.html.erb
+++ b/app/views/loci/_pending_photos.html.erb
@@ -1,0 +1,42 @@
+<div class="rounded-xl border border-[#e0c9a0] bg-[#fcf3e0] p-4 mb-6">
+  <h2 class="font-serif text-2xl text-[#2a231b] mb-1">
+    <%= @pending_photos.size %> pending photo<%= 's' unless @pending_photos.size == 1 %>
+  </h2>
+  <p class="text-sm text-[#6a5d4c] mb-4">
+    Photos uploaded for square <%= @area %>.<%= @square %> not yet linked to a locus.
+    Tick the loci a photo belongs to (it can belong to several) and link it.
+  </p>
+
+  <div class="grid gap-3 grid-cols-[repeat(auto-fill,minmax(240px,1fr))]">
+    <% @pending_photos.each do |photo| %>
+      <div class="bg-white border border-[#ddcfb4] rounded-lg overflow-hidden flex flex-col">
+        <img src="<%= photo.thumb_url %>" alt="" class="h-36 w-full object-cover" loading="lazy">
+        <div class="p-3 flex flex-col gap-2 flex-1">
+          <div class="font-mono text-[11px] text-[#6a5d4c] break-all"><%= photo.filename %></div>
+          <% if photo.name.subject.present? %>
+            <div class="text-xs text-[#9c8e78]"><%= photo.name.subject %></div>
+          <% end %>
+
+          <% if @loci.any? %>
+            <%= form_with url: photo_associate_path, method: :post, local: true, class: "mt-auto" do %>
+              <%= hidden_field_tag :key, photo.key %>
+              <%= hidden_field_tag :return_to, area_square_loci_path(@area, @square) %>
+              <div class="flex flex-wrap gap-x-3 gap-y-1 mb-2 max-h-28 overflow-y-auto">
+                <% @loci.each do |l| %>
+                  <label class="inline-flex items-center gap-1.5 text-sm text-[#2a231b]">
+                    <input type="checkbox" name="locus_ids[]" value="<%= l.id %>" class="rounded border-[#c8a87f]">
+                    <%= l.code %>
+                  </label>
+                <% end %>
+              </div>
+              <%= submit_tag 'Link to selected loci',
+                    class: "w-full rounded-full bg-[#b1542b] px-3 py-1.5 text-white text-sm font-medium hover:bg-[#8d3f1d] cursor-pointer" %>
+            <% end %>
+          <% else %>
+            <p class="text-xs text-[#9c8e78] mt-auto">No loci in this square yet — create one to link photos.</p>
+          <% end %>
+        </div>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/loci/_photos.html.erb
+++ b/app/views/loci/_photos.html.erb
@@ -12,13 +12,19 @@
       </thead>
       <tbody>
         <% @locus.dig('photos').each do |photo| %>
+          <%
+            # Convention-named/bulk photos reference an S3 key; legacy daily
+            # photos reference a number.
+            medium = photo["key"].present? ? Photo.url_for_key(photo["key"], :medium) : Photo.photo_url(photo["number"], :medium)
+            thumb  = photo["key"].present? ? Photo.url_for_key(photo["key"], :thumb)  : Photo.photo_url(photo["number"], :thumb)
+          %>
           <tr class="hover:bg-gray-200">
             <td class="px-4 py-2 text-left"><%= read_date photo["date"] %></td>
-            <td class="px-4 py-2 text-left"><%= photo["number"] %></td>
+            <td class="px-4 py-2 text-left"><%= photo["number"].presence || photo["filename"] %></td>
             <td class="px-4 py-2 text-left"><%= photo["subject"] %></td>
             <td class="px-4 py-2 text-center">
-              <a class="locus-photo-link flex justify-center" href="<%= Photo.photo_url(photo["number"], :medium) %>" data-lightbox="locus-photos">
-                <img class="locus-photo w-32 h-32 object-cover rounded" src="<%= Photo.photo_url(photo["number"], :thumb) %>" alt="" />
+              <a class="locus-photo-link flex justify-center" href="<%= medium %>" data-lightbox="locus-photos">
+                <img class="locus-photo w-32 h-32 object-cover rounded" src="<%= thumb %>" alt="" />
               </a>
             </td>
           </tr>

--- a/app/views/loci/index.html.erb
+++ b/app/views/loci/index.html.erb
@@ -12,6 +12,8 @@
     </div>
   </div>
 
+  <%= render 'loci/pending_photos' if @pending_photos&.any? %>
+
   <!-- Main modal -->
 <div id="newLocusModal" tabindex="-1" aria-hidden="true" class="fixed top-0 left-0 right-0 z-50 hidden w-full p-4 overflow-x-hidden overflow-y-auto md:inset-0 h-[calc(100%-1rem)] max-h-full">
     <div class="relative w-full max-w-2xl max-h-full">

--- a/app/views/photos/review.html.erb
+++ b/app/views/photos/review.html.erb
@@ -1,0 +1,79 @@
+<div class="container mx-auto max-w-5xl px-2 py-8">
+  <div class="mb-6">
+    <h1 class="font-serif text-4xl text-[#2a231b]">Photos</h1>
+    <p class="text-[#6a5d4c] mt-1">
+      All convention-named photos in the bucket and the loci they're linked to.
+      Per-square triage happens on each square's page.
+    </p>
+  </div>
+
+  <% unless @bucket_configured %>
+    <div class="rounded-xl border border-[#e0c9a0] bg-[#fcf3e0] p-4 mb-6 text-[#6a5d4c]">
+      Object storage isn't configured in this environment, so no photos can be listed.
+    </div>
+  <% end %>
+
+  <p class="text-sm text-[#6a5d4c] mb-3"><span class="font-semibold"><%= @unlinked_count %></span> not yet linked to any locus.</p>
+
+  <% if @photos.empty? %>
+    <div class="rounded-xl border border-dashed border-[#ddcfb4] bg-[#fbf6ec] p-12 text-center">
+      <p class="font-serif text-2xl text-[#2a231b] mb-1">No photos found</p>
+      <p class="text-[#6a5d4c]">Upload convention-named photos to the project's <code>daily_photos/</code> prefix to see them here.</p>
+    </div>
+  <% else %>
+    <div class="overflow-x-auto rounded-xl border border-[#ddcfb4]">
+      <table class="w-full text-sm">
+        <thead class="bg-[#f1e9d8] text-left text-[#6a5d4c]">
+          <tr>
+            <th class="px-3 py-3 font-medium">Photo</th>
+            <th class="px-3 py-3 font-medium">Filename</th>
+            <th class="px-3 py-3 font-medium">Square</th>
+            <th class="px-3 py-3 font-medium">Loci</th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-[#e7dcc4] bg-white">
+          <% @photos.each do |p| %>
+            <% entry = p[:entry]; name = entry.name %>
+            <tr class="hover:bg-[#fbf6ec] align-top">
+              <td class="px-3 py-3">
+                <img src="<%= entry.thumb_url %>" alt="" class="w-20 h-20 object-cover rounded" loading="lazy">
+              </td>
+              <td class="px-3 py-3">
+                <div class="font-mono text-xs text-[#2a231b] break-all"><%= entry.filename %></div>
+                <% if name.subject.present? %><div class="text-[#9c8e78] text-xs mt-1"><%= name.subject %></div><% end %>
+              </td>
+              <td class="px-3 py-3 text-[#6a5d4c]">
+                <%= name.valid? ? "#{name.area}.#{name.square}" : '—' %>
+              </td>
+              <td class="px-3 py-3">
+                <% if entry.linked_to.any? %>
+                  <div class="flex flex-wrap gap-1 mb-2">
+                    <% entry.linked_to.each do |code| %>
+                      <span class="inline-flex items-center gap-1 rounded-full bg-[#e7f0e3] px-2.5 py-1 text-xs text-[#3f7d3f] font-medium">✓ <%= code %></span>
+                    <% end %>
+                  </div>
+                <% end %>
+                <% if p[:candidates].any? %>
+                  <%= form_with url: photo_associate_path, method: :post, local: true do %>
+                    <%= hidden_field_tag :key, entry.key %>
+                    <div class="flex flex-wrap gap-x-4 gap-y-1 mb-2">
+                      <% p[:candidates].each do |l| %>
+                        <label class="inline-flex items-center gap-1.5 text-sm text-[#2a231b]">
+                          <input type="checkbox" name="locus_ids[]" value="<%= l[:id] %>" class="rounded border-[#c8a87f]">
+                          <%= "#{l[:area]}.#{l[:square]}.#{l[:code]}" %>
+                        </label>
+                      <% end %>
+                    </div>
+                    <%= submit_tag 'Link selected', class: "rounded-full bg-[#b1542b] px-3 py-1.5 text-white text-sm font-medium hover:bg-[#8d3f1d] cursor-pointer" %>
+                  <% end %>
+                <% elsif entry.linked_to.empty? %>
+                  <span class="text-xs text-[#9c8e78]"><%= name.valid? ? "No loci in #{name.area}.#{name.square} yet" : 'Unrecognized filename' %></span>
+                <% end %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  <% end %>
+</div>

--- a/app/views/projects/edit.html.erb
+++ b/app/views/projects/edit.html.erb
@@ -1,0 +1,30 @@
+<div class="container mx-auto px-4 py-8 max-w-2xl">
+  <nav class="mb-4 text-sm"><%= link_to "← Projects", projects_path, class: "text-[#b1542b] hover:underline" %></nav>
+  <h1 class="font-serif text-3xl text-[#2a231b] mb-1"><%= Project.display_name(@key) %></h1>
+  <p class="text-xs text-[#9c6b3f] uppercase tracking-wide mb-6"><%= @key %></p>
+
+  <%= form_with url: project_path(@key), method: :patch, html: { multipart: true, class: "space-y-5" } do %>
+    <div>
+      <label class="block text-sm font-medium text-[#2a231b] mb-1">Display name</label>
+      <%= text_field_tag :name, @metadata["name"],
+            class: "w-full rounded-md border border-[#ddcfb4] bg-white px-3 py-2 text-[#2a231b] focus:border-[#9c6b3f] focus:outline-none" %>
+    </div>
+    <div>
+      <label class="block text-sm font-medium text-[#2a231b] mb-1">Description</label>
+      <%= text_area_tag :description, @metadata["description"], rows: 4,
+            class: "w-full rounded-md border border-[#ddcfb4] bg-white px-3 py-2 text-[#2a231b] focus:border-[#9c6b3f] focus:outline-none" %>
+    </div>
+    <div>
+      <label class="block text-sm font-medium text-[#2a231b] mb-1">Cover photo</label>
+      <% if @cover_url.present? %>
+        <img src="<%= @cover_url %>" alt="" class="h-32 rounded-md object-cover mb-2">
+      <% end %>
+      <%= file_field_tag :cover, accept: "image/*", class: "block text-sm text-[#6a5d4c]" %>
+      <p class="text-xs text-[#9c6b3f] mt-1">Upload to replace the current cover.</p>
+    </div>
+    <div class="flex items-center gap-3 pt-2">
+      <%= submit_tag "Save changes", class: "rounded-full bg-[#b1542b] px-5 py-2 text-white font-medium hover:bg-[#8d3f1d] cursor-pointer" %>
+      <%= link_to "Cancel", projects_path, class: "text-[#6a5d4c] hover:underline" %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -1,0 +1,44 @@
+<div class="container mx-auto px-4 py-8">
+  <div class="flex items-end flex-wrap gap-4 mb-8">
+    <div>
+      <h1 class="font-serif text-4xl text-[#2a231b]">Projects</h1>
+      <p class="text-[#6a5d4c] mt-1">Create and manage digs, cover photos, and descriptions.</p>
+    </div>
+    <div class="ml-auto">
+      <%= link_to new_project_path, class: "inline-flex items-center gap-2 rounded-full bg-[#b1542b] px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-[#8d3f1d] transition-colors" do %>
+        <span class="text-lg leading-none">+</span> New project
+      <% end %>
+    </div>
+  </div>
+
+  <% if @projects.empty? %>
+    <div class="rounded-xl border border-dashed border-[#ddcfb4] bg-[#fbf6ec] p-12 text-center">
+      <p class="font-serif text-2xl text-[#2a231b] mb-1">No projects yet</p>
+      <p class="text-[#6a5d4c]">Create your first project to get started.</p>
+    </div>
+  <% else %>
+    <div class="grid gap-4 grid-cols-[repeat(auto-fill,minmax(260px,1fr))]">
+      <% @projects.each do |p| %>
+        <div class="bg-[#fbf6ec] border border-[#ddcfb4] rounded-xl overflow-hidden flex flex-col">
+          <% if p[:cover_url].present? %>
+            <img src="<%= p[:cover_url] %>" alt="" class="h-32 w-full object-cover">
+          <% else %>
+            <div class="h-32 w-full bg-[#e8dcc5] flex items-center justify-center text-[#9c6b3f] text-sm">No cover photo</div>
+          <% end %>
+          <div class="p-4 flex flex-col gap-2 flex-1">
+            <div class="font-serif text-xl text-[#2a231b]"><%= p[:name] %></div>
+            <div class="text-xs text-[#9c6b3f] uppercase tracking-wide"><%= p[:key] %></div>
+            <% if p[:description].present? %>
+              <p class="text-sm text-[#6a5d4c] line-clamp-3"><%= p[:description] %></p>
+            <% end %>
+            <div class="mt-auto flex items-center gap-3 pt-2">
+              <%= link_to "Edit", edit_project_path(p[:key]), class: "text-[#b1542b] font-medium text-sm hover:underline" %>
+              <% port = request.optional_port ? ":#{request.optional_port}" : "" %>
+              <a class="text-[#6a5d4c] text-sm hover:underline" href="<%= "#{request.protocol}#{p[:key]}.#{request.domain}#{port}/" %>">Open dig →</a>
+            </div>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/projects/new.html.erb
+++ b/app/views/projects/new.html.erb
@@ -1,0 +1,32 @@
+<div class="container mx-auto px-4 py-8 max-w-2xl">
+  <nav class="mb-4 text-sm"><%= link_to "← Projects", projects_path, class: "text-[#b1542b] hover:underline" %></nav>
+  <h1 class="font-serif text-3xl text-[#2a231b] mb-6">New Project</h1>
+
+  <%= form_with url: projects_path, method: :post, html: { multipart: true, class: "space-y-5" } do %>
+    <div>
+      <label class="block text-sm font-medium text-[#2a231b] mb-1">Project key *</label>
+      <%= text_field_tag :key, params[:key], required: true, placeholder: "e.g. balua",
+            class: "w-full rounded-md border border-[#ddcfb4] bg-white px-3 py-2 text-[#2a231b] focus:border-[#9c6b3f] focus:outline-none" %>
+      <p class="text-xs text-[#9c6b3f] mt-1">Lowercase identifier; becomes the subdomain and database name. Letters, numbers, underscores.</p>
+    </div>
+    <div>
+      <label class="block text-sm font-medium text-[#2a231b] mb-1">Display name</label>
+      <%= text_field_tag :name, params[:name], placeholder: "e.g. Tall al-‘Umayri",
+            class: "w-full rounded-md border border-[#ddcfb4] bg-white px-3 py-2 text-[#2a231b] focus:border-[#9c6b3f] focus:outline-none" %>
+    </div>
+    <div>
+      <label class="block text-sm font-medium text-[#2a231b] mb-1">Description</label>
+      <%= text_area_tag :description, params[:description], rows: 4,
+            class: "w-full rounded-md border border-[#ddcfb4] bg-white px-3 py-2 text-[#2a231b] focus:border-[#9c6b3f] focus:outline-none" %>
+    </div>
+    <div>
+      <label class="block text-sm font-medium text-[#2a231b] mb-1">Cover photo</label>
+      <%= file_field_tag :cover, accept: "image/*", class: "block text-sm text-[#6a5d4c]" %>
+      <p class="text-xs text-[#9c6b3f] mt-1">Optional. Shown on the project home page.</p>
+    </div>
+    <div class="flex items-center gap-3 pt-2">
+      <%= submit_tag "Create project", class: "rounded-full bg-[#b1542b] px-5 py-2 text-white font-medium hover:bg-[#8d3f1d] cursor-pointer" %>
+      <%= link_to "Cancel", projects_path, class: "text-[#6a5d4c] hover:underline" %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/shared/landing.html.erb
+++ b/app/views/shared/landing.html.erb
@@ -120,13 +120,28 @@
 
     <% if signed_in %>
       <section class="digs">
-        <h2>Your digs</h2>
-        <p class="sub">Projects you have access to. Pick one to enter the field record.</p>
+        <div style="display:flex;align-items:flex-end;gap:1rem;flex-wrap:wrap;margin-bottom:1.6rem">
+          <div>
+            <h2>Your digs</h2>
+            <p class="sub" style="margin-bottom:0">Projects you have access to. Pick one to enter the field record.</p>
+          </div>
+          <% if current_user.superuser? %>
+            <a class="btn btn-primary" style="margin-left:auto" href="<%= projects_path %>">Manage projects</a>
+          <% end %>
+        </div>
         <% if digs.any? %>
           <div class="dig-grid">
             <% digs.each do |key| %>
+              <% cover = Project.cover_photo_url(key, :thumb) %>
+              <% desc = Project.description(key) %>
               <a class="dig-card" href="<%= "#{request.protocol}#{key}.#{request.domain}#{port}/" %>">
-                <span class="name"><%= key.humanize %></span>
+                <% if cover.present? %>
+                  <img src="<%= cover %>" alt="" style="width:100%;height:120px;object-fit:cover;border-radius:10px;margin-bottom:.3rem">
+                <% end %>
+                <span class="name"><%= Project.display_name(key) %></span>
+                <% if desc.present? %>
+                  <span style="color:var(--ink-soft);font-size:.9rem;line-height:1.45"><%= truncate(desc, length: 130) %></span>
+                <% end %>
                 <span class="go">Enter the dig →</span>
               </a>
             <% end %>

--- a/config/descriptions.json
+++ b/config/descriptions.json
@@ -2254,6 +2254,16 @@
         "time_level": "Period modifier",
         "question": "Reading modifier"
     },
+    "find_declaration": {
+        "categories": [
+            { "key": "field_find", "label": "Field Find" },
+            { "key": "sample", "label": "Sample" }
+        ],
+        "sample_types": [
+            { "key": "C14", "label": "C14" },
+            { "key": "Soil", "label": "Soil" }
+        ]
+    },
     "finds": [
         {
             "key": "field_number",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,6 +35,13 @@ Rails.application.routes.draw do
   resources :registrar
   resources :bulk_uploads, only: %i[new create]
 
+  # Bulk locus-photo association (parse convention-named photos -> suggest loci).
+  get  '/photos',           to: 'photos#review',    as: :photos_review
+  post '/photos/associate', to: 'photos#associate', as: :photo_associate
+
+  # Superuser project administration (runs at the apex host, no subdomain).
+  resources :projects, only: %i[index new create edit update]
+
   patch '/admin/update_user/:id', to: 'admin#update_user', as: :admin_update_user
   resources :admin, only: [] do
     collection do
@@ -57,6 +64,7 @@ Rails.application.routes.draw do
       post   'devices/pair',    to: 'devices#pair'
       delete 'devices/current', to: 'devices#destroy'
       get    'config',          to: 'config#show'
+      get    'photos/pending',  to: 'photos#pending'
     end
   end
 

--- a/config/views.yaml
+++ b/config/views.yaml
@@ -1,5 +1,5 @@
 ---
-:version: 12
+:version: 15
 :design:
   "_id": _design/opendig
   :views:
@@ -98,6 +98,18 @@
           }
         }
       :reduce: "function(keys,values){return true;}"
+    :photo_keys:
+      :map: >
+        function (doc) {
+          if (doc.photos) {
+            for (var _p in doc.photos) {
+              var photo = doc.photos[_p];
+              if (photo.key) {
+                emit(photo.key, [doc.area + '.' + doc.square + '.' + doc.code, doc._id]);
+              }
+            }
+          }
+        }
     :seasons:
       :map: >
         function (doc) {

--- a/lib/tasks/photos.rake
+++ b/lib/tasks/photos.rake
@@ -28,7 +28,11 @@ namespace :photos do
         loci_changed = 0
         photos_fixed = 0
         ids.each do |id|
-          doc = (db.get(id) rescue nil)
+          doc = begin
+            db.get(id)
+          rescue StandardError
+            nil
+          end
           next unless doc && doc['photos'].is_a?(Array)
 
           changed = false

--- a/lib/tasks/photos.rake
+++ b/lib/tasks/photos.rake
@@ -1,0 +1,59 @@
+# Migrate legacy numbered locus photos to the new key-based model.
+#
+# Old model: locus.photos[] entries reference a `number`; the file lives at
+#   <project>/daily_photos/<number>.<ext>  and is rendered via Photo.photo_url.
+# New model: entries also carry a `key` (the full S3 object key) and are
+#   rendered via Photo.url_for_key — the same way convention-named photos are.
+#
+# The files DON'T move (they're already in daily_photos/), so this is a
+# metadata-only backfill: it adds `key` (+ `filename`) to each numbered photo
+# that doesn't have one yet. Idempotent.
+#
+#   # preview, all projects:
+#   RAILS_ENV=production DRY_RUN=1 bin/rails photos:backfill_keys
+#   # apply, one project:
+#   RAILS_ENV=production bin/rails 'photos:backfill_keys[balua]'
+namespace :photos do
+  desc 'Backfill key-based references onto legacy numbered locus photos (DRY_RUN=1 to preview)'
+  task :backfill_keys, %i[project] => :environment do |_t, args|
+    dry = ENV['DRY_RUN'].present?
+    projects = args[:project].present? ? [args[:project]] : Project.all
+
+    projects.each do |project|
+      CouchDB.with_project(project) do
+        db = CouchDB.main_db
+        ids = db.view('opendig/loci', reduce: false)['rows']
+                .map { |row| row['key'][3] }.compact.uniq
+
+        loci_changed = 0
+        photos_fixed = 0
+        ids.each do |id|
+          doc = (db.get(id) rescue nil)
+          next unless doc && doc['photos'].is_a?(Array)
+
+          changed = false
+          doc['photos'].each do |photo|
+            next if photo['key'].present? # already migrated / convention photo
+
+            number = photo['number'].to_s
+            next if number.blank?
+
+            key = Photo.object_key_for(number) ||
+                  "#{ProjectStorage.daily_photos_prefix}/#{number}.JPG"
+            photo['key'] = key
+            photo['filename'] ||= File.basename(key)
+            changed = true
+            photos_fixed += 1
+          end
+
+          if changed
+            loci_changed += 1
+            db.save_doc(doc) unless dry
+          end
+        end
+
+        puts "#{project}: #{photos_fixed} photo(s) on #{loci_changed} locus/loci#{dry ? ' (dry run, not saved)' : ''}"
+      end
+    end
+  end
+end

--- a/spec/models/photo_name_spec.rb
+++ b/spec/models/photo_name_spec.rb
@@ -1,0 +1,58 @@
+require 'rails_helper'
+
+RSpec.describe PhotoName, type: :model do
+  describe '.parse' do
+    subject(:name) { described_class.parse('B26.08.92.001.0621_Progress.JPG') }
+
+    it 'splits the convention into its parts' do
+      expect(name).to be_valid
+      expect(name.season).to eq('B26')
+      expect(name.area).to eq('08')
+      expect(name.square).to eq('92')
+      expect(name.sequence).to eq('001')
+      expect(name.date).to eq('0621')
+      expect(name.subject).to eq('Progress')
+      expect(name.ext).to eq('.JPG')
+    end
+
+    it 'derives the calendar year from the season code' do
+      expect(name.season_year).to eq(2026)
+    end
+
+    it 'builds the locus code' do
+      expect(name.locus_code).to eq('08.92.001')
+    end
+
+    it 'tolerates a missing subject' do
+      n = described_class.parse('B26.08.92.001.0621.jpg')
+      expect(n).to be_valid
+      expect(n.subject).to be_nil
+    end
+
+    it 'marks non-conforming filenames invalid' do
+      n = described_class.parse('IMG_1234.jpg')
+      expect(n).not_to be_valid
+      expect(n.suggest_loci([{ area: '8', square: '92', code: '1' }])).to eq([])
+    end
+  end
+
+  describe '#suggest_loci' do
+    subject(:name) { described_class.parse('B26.08.92.001.0621_Progress.JPG') }
+
+    let(:loci) do
+      [
+        { area: '08', square: '92', code: '1', id: 'locA' },
+        { area: '8',  square: '92', code: '2', id: 'locB' }, # numeric-normalized match
+        { area: '9',  square: '1',  code: '1', id: 'locZ' },
+      ]
+    end
+
+    it 'returns ALL loci in the photo area+square (a photo can belong to many)' do
+      expect(name.suggest_loci(loci).map { |l| l[:id] }).to eq(%w[locA locB])
+    end
+
+    it 'returns nothing when no locus shares the area/square' do
+      expect(name.suggest_loci([{ area: '1', square: '1', code: '1', id: 'x' }])).to eq([])
+    end
+  end
+end

--- a/spec/models/photo_name_spec.rb
+++ b/spec/models/photo_name_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe PhotoName, type: :model do
       [
         { area: '08', square: '92', code: '1', id: 'locA' },
         { area: '8',  square: '92', code: '2', id: 'locB' }, # numeric-normalized match
-        { area: '9',  square: '1',  code: '1', id: 'locZ' },
+        { area: '9',  square: '1',  code: '1', id: 'locZ' }
       ]
     end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -45,7 +45,10 @@ RSpec.configure do |config|
   # that project as existing (avoids a live _all_dbs lookup).
   config.before(:each, type: :controller) do
     request.host = 'opendig.example.com'
-    allow(Project).to receive(:exists?).with('opendig').and_return(true)
+    # `opendig` is the test project; any other key is treated as absent. A block
+    # stub (rather than `.with('opendig')`) tolerates the optional `env:` kwarg
+    # Project.exists? now accepts and the per-dig lookups the landing page makes.
+    allow(Project).to receive(:exists?) { |key, **| key.to_s == 'opendig' }
   end
 
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures


### PR DESCRIPTION
## Photos
- **PhotoName** — parses the `Season.Area.Square.Sequence.Date_Subject` filename convention and suggests in-square loci (many-to-many; unit-spec'd).
- **BulkPhoto** — lists convention-named photos in `{project}/daily_photos/` and tracks which loci each is linked to (new `opendig/photo_keys` view).
- **Per-square "pending photos"** section on the loci page + a project-wide `/photos` page (nav item): link a photo to one or more loci (writes to `locus.photos[]` by S3 key).
- **Device API** `GET /api/v1/photos/pending` powering the mobile per-square triage.
- Locus photos render by S3 key (`Photo.url_for_key`) with a number fallback.
- `rake photos:backfill_keys` — migrate legacy numbered photos to key-based references (metadata only; files already live in `daily_photos/`, dry-run supported).

## Project admin (superuser, apex host)
- `ProjectsController` + views: provision a project (creates the CouchDB database), manage display name / description / cover photo. Cover + description show on the apex landing and the project home, and are included in the device config bundle.
- `resolve_project` lets the apex host serve project admin.

## Other
- `descriptions.json`: `find_declaration` (field find / sample + sample sub-types).

## Notes
- `config/views.yaml` bumped to v15 (adds `photo_keys`) — design docs update on boot.
- Verified by Ruby/ERB/YAML syntax checks and the `PhotoName` spec; full Rails suite not run in this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)