### PR TITLE
Photo /photos page: sharper previews, full-size, square links, pending-only triage

### DIFF
--- a/app/controllers/api/v1/photos_controller.rb
+++ b/app/controllers/api/v1/photos_controller.rb
@@ -22,8 +22,12 @@ module Api
               filename: entry.filename,
               subject: entry.name.subject,
               date: entry.name.date,
-              thumb_url: Photo.url_for_key(entry.key, :thumb),
-              url: Photo.url_for_key(entry.key, :medium)
+              # thumb_url is bumped to the crisp `preview` size so existing app
+              # builds (which read thumb_url) get sharp images with no rebuild.
+              thumb_url: Photo.url_for_key(entry.key, :preview),
+              preview_url: Photo.url_for_key(entry.key, :preview),
+              url: Photo.url_for_key(entry.key, :medium),
+              full_url: Photo.url_for_key(entry.key, :original)
             }
           end
         end

--- a/app/models/bulk_photo.rb
+++ b/app/models/bulk_photo.rb
@@ -5,6 +5,8 @@ class BulkPhoto
   Entry = Struct.new(:key, :name, :linked_to, keyword_init: true) do
     def filename = File.basename(key)
     def thumb_url = Photo.url_for_key(key, :thumb)
+    def preview_url = Photo.url_for_key(key, :preview)
+    def full_url = Photo.url_for_key(key, :original)
     def pending? = linked_to.empty?
   end
 

--- a/app/models/photo.rb
+++ b/app/models/photo.rb
@@ -5,6 +5,14 @@ class Photo
         height: 1000,
         width: 1000
       },
+      # Crisp on-the-fly preview for photo grids/cards. Larger than `thumb` so it
+      # stays sharp on hi-DPI screens; `fit` keeps the whole frame (CSS crops it).
+      preview: {
+        height: 600,
+        width: 600,
+        resizing_type: 'fit',
+        quality: 82
+      },
       thumb: {
         height: 100,
         width: 100

--- a/app/views/loci/_pending_photos.html.erb
+++ b/app/views/loci/_pending_photos.html.erb
@@ -10,7 +10,9 @@
   <div class="grid gap-3 grid-cols-[repeat(auto-fill,minmax(240px,1fr))]">
     <% @pending_photos.each do |photo| %>
       <div class="bg-white border border-[#ddcfb4] rounded-lg overflow-hidden flex flex-col">
-        <img src="<%= photo.thumb_url %>" alt="" class="h-36 w-full object-cover" loading="lazy">
+        <a href="<%= photo.full_url %>" target="_blank" rel="noopener" title="Open full size">
+          <img src="<%= photo.preview_url %>" alt="" class="h-44 w-full object-cover hover:opacity-90 transition" loading="lazy">
+        </a>
         <div class="p-3 flex flex-col gap-2 flex-1">
           <div class="font-mono text-[11px] text-[#6a5d4c] break-all"><%= photo.filename %></div>
           <% if photo.name.subject.present? %>

--- a/app/views/photos/review.html.erb
+++ b/app/views/photos/review.html.erb
@@ -36,7 +36,9 @@
             <% entry = p[:entry]; name = entry.name %>
             <tr class="hover:bg-[#fbf6ec] align-top">
               <td class="px-3 py-3">
-                <img src="<%= entry.thumb_url %>" alt="" class="w-20 h-20 object-cover rounded" loading="lazy">
+                <a href="<%= entry.full_url %>" target="_blank" rel="noopener" title="Open full size">
+                  <img src="<%= entry.preview_url %>" alt="" class="w-28 h-28 object-cover rounded ring-1 ring-[#e7dcc4] hover:opacity-90 transition" loading="lazy">
+                </a>
               </td>
               <td class="px-3 py-3">
                 <div class="font-mono text-xs text-[#2a231b] break-all"><%= entry.filename %></div>


### PR DESCRIPTION
Improvements to the web photo-linking (`/photos`) experience and the per-square pending cards.

## Previews
- New imgproxy **`preview`** style (600px, `fit`, q82) replaces the blurry 100×100 `thumb` on `/photos` and the per-square "pending photos" cards.
- Each thumbnail **links to the full-size original** (opens in a new tab).
- The mobile `pending` endpoint returns `preview_url` + `full_url`, and `thumb_url` is bumped to the preview size so already-installed app builds get sharp images with no rebuild.

## Triage flow
- `/photos` now lists **only photos still waiting to be linked**. Once a photo is linked to any locus it drops off on the next load (the `associate` action already redirects back). It's a triage queue, not a full inventory.
- The **Square** column links straight to that square's loci page.

## Notes
- rubocop clean; ERB parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)