### PR TITLE
Restore full-size photo lightbox modal

### DIFF
--- a/app/views/loci/_pending_photos.html.erb
+++ b/app/views/loci/_pending_photos.html.erb
@@ -12,9 +12,12 @@
   <div class="grid gap-3 grid-cols-[repeat(auto-fill,minmax(240px,1fr))]">
     <% @pending_photos.each do |photo| %>
       <div class="bg-white border border-[#ddcfb4] rounded-lg overflow-hidden flex flex-col">
-        <a href="<%= photo.full_url %>" target="_blank" rel="noopener" title="Open full size">
-          <img src="<%= photo.preview_url %>" alt="" class="h-44 w-full object-cover hover:opacity-90 transition" loading="lazy">
-        </a>
+        <img src="<%= photo.preview_url %>" alt=""
+             data-full="<%= photo.full_url %>"
+             data-filename="<%= photo.filename %>"
+             data-subject="<%= photo.name.subject %>"
+             @click="open=true; img=$el.dataset.full; filename=$el.dataset.filename; subject=$el.dataset.subject"
+             class="h-44 w-full object-cover hover:opacity-90 transition cursor-pointer" loading="lazy" title="View full size">
         <div class="p-3 flex flex-col gap-2 flex-1">
           <div class="font-mono text-[11px] text-[#6a5d4c] break-all"><%= photo.filename %></div>
           <% if photo.name.subject.present? %>

--- a/app/views/photos/review.html.erb
+++ b/app/views/photos/review.html.erb
@@ -39,9 +39,13 @@
             <% entry = p[:entry]; name = entry.name %>
             <tr class="hover:bg-[#fbf6ec] align-top">
               <td class="px-3 py-3">
-                <a href="<%= entry.full_url %>" target="_blank" rel="noopener" title="Open full size">
-                  <img src="<%= entry.preview_url %>" alt="" class="w-28 h-28 object-cover rounded ring-1 ring-[#e7dcc4] hover:opacity-90 transition" loading="lazy">
-                </a>
+                <img src="<%= entry.preview_url %>" alt=""
+                     data-full="<%= entry.full_url %>"
+                     data-filename="<%= entry.filename %>"
+                     data-subject="<%= name.subject %>"
+                     data-square="<%= name.valid? ? "#{name.area}.#{name.square}" : '' %>"
+                     @click="open=true; img=$el.dataset.full; filename=$el.dataset.filename; subject=$el.dataset.subject; square=$el.dataset.square"
+                     class="w-28 h-28 object-cover rounded ring-1 ring-[#e7dcc4] hover:opacity-90 transition cursor-pointer" loading="lazy" title="View full size">
               </td>
               <td class="px-3 py-3">
                 <div class="font-mono text-xs text-[#2a231b] break-all"><%= entry.filename %></div>


### PR DESCRIPTION
## Why
A bad conflict resolution while merging #59 left `main` in a broken partial state: the lightbox modal markup was present, but the photo thumbnails on `/photos` and the per-square pending cards had been reverted to the old new-tab `<a>` links — so clicking a photo opened a new tab (or nothing) instead of the modal.

## What
Restores the known-good thumbnail triggers so clicking a photo opens the in-page **Alpine lightbox** (full-size image + filename/subject/square below), closing on ✕ / backdrop / Esc — on both `/photos` and the per-square pending cards.

Net change is just the thumbnail `@click` handlers (the modal block was already on main).

## Notes
- ERB parses on both views; no new dependencies (Alpine is already loaded by the layout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)