### PR TITLE
Fix 500 on locus show for legacy Hash-shaped pails/finds/readings

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,13 @@
 module ApplicationHelper
+  # Normalize an embedded collection (pails, readings, finds) into an array of
+  # hashes for iteration. Most docs store these as an array, but some legacy
+  # docs store them as a Hash keyed by id -- iterating that yields [key, value]
+  # pairs and blows up on item['field']. Coerce both shapes and drop non-hashes.
+  def hash_rows(collection)
+    rows = collection.is_a?(Hash) ? collection.values : collection
+    Array(rows).select { |row| row.is_a?(Hash) }
+  end
+
   # Always begin the OAuth handshake on the apex domain (opendig.org), so the
   # provider (Google) needs only one registered redirect URI instead of one per
   # subdomain. The `origin` carries the user back to the subdomain they started

--- a/app/views/loci/_pails.html.erb
+++ b/app/views/loci/_pails.html.erb
@@ -15,7 +15,7 @@
         </tr>
       </thead>
       <tbody>
-        <% @locus.dig('pails').each do |pail| %>
+        <% hash_rows(@locus['pails']).each do |pail| %>
           <tr class="hover:bg-gray-200">
             <td class="px-4 py-2"><%= pail["pail_number"] %></td>
             <td class="px-4 py-2"><%= read_date(pail["pail_date"]) %></td>
@@ -25,7 +25,7 @@
             <td class="px-4 py-2"><%= pail["publish"] %></td>
           </tr>
           <!-- ... -->
-          <% if pail['readings'].present? %>
+          <% if hash_rows(pail['readings']).any? %>
             <tr>
               <td></td>
               <td colspan="5" class="px-4 py-2">
@@ -42,7 +42,7 @@
                     </tr>
                   </thead>
                   <tbody>
-                    <% pail.dig('readings').each do |reading| %>
+                    <% hash_rows(pail['readings']).each do |reading| %>
                       <tr class="hover:bg-gray-200">
                         <td class="pl-4 pr-10 text-left"><%= reading['count'] %></td>
                         <td class="pl-4 pr-10 text-left"><%= reading['quantity_modifier'] %></td>
@@ -59,7 +59,7 @@
           <% end %>
           <!-- ... -->
 
-          <% if pail['finds'].present? %>
+          <% if hash_rows(pail['finds']).any? %>
             <tr>
               <td></td>
               <td colspan="5" class="px-4 py-2">
@@ -78,7 +78,7 @@
                     </tr>
                   </thead>
                   <tbody>
-                    <% pail.dig('finds').each do |find| %>
+                    <% hash_rows(pail['finds']).each do |find| %>
                       <tr class="hover:bg-gray-200">
                         <td><%= find['field_number'] %></td>
                         <td><%= find['registration_number'] %></td>


### PR DESCRIPTION
## Bug
Opening a locus (e.g. `08.92.001`) 500'd with `no implicit conversion of String into Integer` at `find['field_number']` in `loci/_pails.html.erb`.

## Cause
Some older docs store a pail's `finds` (and `readings`, and the locus's `pails`) as a **Hash keyed by id** rather than an array. Iterating a Hash yields `[key, value]` pairs, so `find` was a 2-element Array and `find['field_number']` (i.e. `Array#['field_number']`) raised.

## Fix
- Add `ApplicationHelper#hash_rows` that coerces either shape (Array **or** Hash) into an array of hashes, dropping any non-hash entries.
- Use it for the `pails`, `readings`, and `finds` loops, and for the readings/finds section guards (so legacy/empty data renders nothing instead of crashing).

Verified: rubocop clean, ERB parses, helper logic unit-checked (array→ok, legacy hash→ok, nil/junk→empty).

🤖 Generated with [Claude Code](https://claude.com/claude-code)