### PR TITLE
Supplement sheets + harden locus views against legacy Hash collections

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -134,6 +134,37 @@ module ApplicationHelper
     end
   end
 
+  # supplement_type => description field-set it reuses (architecture_description, etc.)
+  def supplement_types
+    @descriptions['supplements'] || {}
+  end
+
+  # Renders one supplement field, scoped to a specific supplement row index so
+  # each supplement is an independent hash in locus[supplements]. Mirrors
+  # input_for but with explicit array indices (locus[supplements][i][key]) so
+  # heterogeneous supplement types don't get column-zipped together.
+  def supplement_input_for(entry, value, index)
+    name = "locus[supplements][#{index}][#{entry['key']}]"
+    case entry['type']
+    when 'picker', 'munsel_picker'
+      options = if entry['values'].is_a?(Hash)
+                  @descriptions['lookups'][entry['values']['from']]
+                else
+                  entry['values']
+                end
+      select_tag name, options_for_select(options || [], value), include_blank: true, class: 'form-control'
+    when 'checkbox'
+      hidden_field_tag(name, '0', id: nil) +
+        check_box_tag(name, '1', ActiveModel::Type::Boolean.new.cast(value), class: 'form-control')
+    when 'text_area'
+      text_area_tag name, value, rows: 3, class: 'form-control'
+    when 'date'
+      text_field_tag name, value, type: 'date', class: 'form-control'
+    else
+      text_field_tag name, value, class: 'form-control'
+    end
+  end
+
   def input_with_full_param_name(form_definition_hash, value, full_param_name)
     puts "input_with_full_param_name: #{form_definition_hash.inspect}"
 

--- a/app/views/loci/_form.html.erb
+++ b/app/views/loci/_form.html.erb
@@ -1,4 +1,4 @@
-<% %w[general_form interpretation_form descriptions_form stratigraphy_form levels_form photos_form pails_form].each do |partial| %>
+<% %w[general_form interpretation_form descriptions_form supplements_form stratigraphy_form levels_form photos_form pails_form].each do |partial| %>
   <section class="ls-section">
     <%= render partial, locus_form: locus_form %>
   </section>

--- a/app/views/loci/_levels.html.erb
+++ b/app/views/loci/_levels.html.erb
@@ -12,7 +12,7 @@
         </tr>
       </thead>
       <tbody>
-        <% @locus.dig('levels').each do |level| %>
+        <% hash_rows(@locus['levels']).each do |level| %>
           <tr>
             <td class="px-4 py-2"><%= level["location"] %></td>
             <td class="px-4 py-2"><%= level_or_nil(level["top_level"]) %></td>

--- a/app/views/loci/_levels_form.html.erb
+++ b/app/views/loci/_levels_form.html.erb
@@ -5,7 +5,7 @@
 </div>
 <div class="row">
   <div class="col level-container">
-    <% @locus['levels']&.each do |level| %>
+    <% hash_rows(@locus['levels']).each do |level| %>
       <%= render 'level_form_row', level: level %>
     <% end %>
   </div>

--- a/app/views/loci/_pail_form_row.html.erb
+++ b/app/views/loci/_pail_form_row.html.erb
@@ -38,7 +38,7 @@
       </div>
       <div class="form-group col-md-4 pail-<%= index %>-reading-container">
         <h3>Pail <%= pail['pail_number'] %> Readings</h3>
-        <% pail['readings']&.each_with_index do |reading, reading_index| %>
+        <% hash_rows(pail['readings']).each_with_index do |reading, reading_index| %>
           <%= render 'pail_reading_form_row', pail: pail, reading: reading, pail_index: index, reading_index: reading_index  %>
         <% end %>
       </div>
@@ -46,7 +46,7 @@
       </div>
       <div class="form-group col-md-4 pail-<%= index %>-find-container">
         <h3>Pail <%= pail['pail_number'] %> Finds</h3>
-        <% pail['finds']&.each_with_index do |find, find_index| %>
+        <% hash_rows(pail['finds']).each_with_index do |find, find_index| %>
           <%= render 'pail_find_form_row', pail: pail, find: find, pail_index: index, find_index: find_index  %>
         <% end %>
       </div>

--- a/app/views/loci/_pails_form.html.erb
+++ b/app/views/loci/_pails_form.html.erb
@@ -11,7 +11,7 @@
 </div>
 <div class="row">
   <div class="col pail-container">
-    <% @locus['pails']&.each_with_index do |pail, index| %>
+    <% hash_rows(@locus['pails']).each_with_index do |pail, index| %>
       <%= render 'pail_form_row', pail: pail, index: index  %>
     <% end %>
   </div>

--- a/app/views/loci/_photos.html.erb
+++ b/app/views/loci/_photos.html.erb
@@ -11,7 +11,7 @@
         </tr>
       </thead>
       <tbody>
-        <% @locus.dig('photos').each do |photo| %>
+        <% hash_rows(@locus['photos']).each do |photo| %>
           <%
             # Convention-named/bulk photos reference an S3 key; legacy daily
             # photos reference a number.

--- a/app/views/loci/_photos_form.html.erb
+++ b/app/views/loci/_photos_form.html.erb
@@ -5,7 +5,7 @@
 </div>
 <div class="row">
   <div class="col photo-container">
-    <% @locus['photos']&.each_with_index do |photo, index| %>
+    <% hash_rows(@locus['photos']).each_with_index do |photo, index| %>
       <%= render 'photo_form_row', photo: photo, index: index  %>
     <% end %>
   </div>

--- a/app/views/loci/_pottery.html.erb
+++ b/app/views/loci/_pottery.html.erb
@@ -15,7 +15,7 @@
         </tr>
       </thead>
       <tbody>
-        <% @locus.dig('pails').each do |pail| %>
+        <% hash_rows(@locus['pails']).each do |pail| %>
           <tr class="hover:bg-gray-200">
             <td class="px-4 py-2"><%= l read_date(pail["pail_date"]) %></td>
             <td class="px-4 py-2"><%= pail["pail_number"] %></td>
@@ -31,8 +31,8 @@
               </td>
             </tr>
           <% end %>
-          <% if pail["readings"] %>
-            <% pail["readings"].group_by { |reading| reading["age"] }.each do |age, readings| %>
+          <% if hash_rows(pail["readings"]).any? %>
+            <% hash_rows(pail["readings"]).group_by { |reading| reading["age"] }.each do |age, readings| %>
               <tr>
                 <td colspan="6" class="px-4 py-2">
                   <h3 class="text-lg font-semibold mb-2">Age: <%= age %></h3>

--- a/app/views/loci/_stratigraphy.html.erb
+++ b/app/views/loci/_stratigraphy.html.erb
@@ -10,7 +10,7 @@
         </tr>
       </thead>
       <tbody>
-        <% @locus.dig('stratigraphies').each do |stratigraphy_row| %>
+        <% hash_rows(@locus['stratigraphies']).each do |stratigraphy_row| %>
           <tr>
             <td><%= stratigraphy_row["is_related"] %></td>
             <td><%= stratigraphy_row["related"] %></td>

--- a/app/views/loci/_stratigraphy_form.html.erb
+++ b/app/views/loci/_stratigraphy_form.html.erb
@@ -5,7 +5,7 @@
 </div>
 <div class="row">
   <div class="col stratigraphy-container">
-    <% @locus['stratigraphies']&.each do |stratigraphy| %>
+    <% hash_rows(@locus['stratigraphies']).each do |stratigraphy| %>
       <%= render 'stratigraphy_form_row', stratigraphy: stratigraphy %>
     <% end %>
   </div>

--- a/app/views/loci/_supplement_block.html.erb
+++ b/app/views/loci/_supplement_block.html.erb
@@ -1,0 +1,35 @@
+<%# Editable block for one supplement. `index` is the row index (or the literal
+    __INDEX__ token when rendered inside an add-template that JS clones). %>
+<% field_set = supplement_types[stype] %>
+<div class="supplement-block border border-[#ddcfb4] rounded-lg p-3 mb-4 bg-white">
+  <div class="flex justify-between items-center mb-2">
+    <h2 class="font-serif text-lg font-semibold text-[#2a231b]"><%= stype.titleize %></h2>
+    <button type="button" class="btn btn-danger btn-sm" onclick="this.closest('.supplement-block').remove();">Remove</button>
+  </div>
+  <input type="hidden" name="locus[supplements][<%= index %>][supplement_type]" value="<%= stype %>">
+  <div class="form-row flex flex-wrap gap-3 mb-2">
+    <div class="form-group">
+      <label>Date</label>
+      <input type="date" name="locus[supplements][<%= index %>][supplement_date]" value="<%= supp['supplement_date'] %>" class="form-control">
+    </div>
+    <div class="form-group">
+      <label>Recorder</label>
+      <input type="text" name="locus[supplements][<%= index %>][recorder]" value="<%= supp['recorder'] %>" class="form-control">
+    </div>
+  </div>
+  <% if field_set && @descriptions[field_set].present? %>
+    <% @descriptions[field_set].each do |section| %>
+      <details class="group mt-2">
+        <summary class="cursor-pointer font-serif font-semibold text-[#2a231b] hover:text-[#b1542b]"><%= section[0] %></summary>
+        <div class="mt-2 space-y-2">
+          <% section[1].each do |entry| %>
+            <div class="form-group">
+              <label><%= entry['label'] %></label>
+              <%= supplement_input_for(entry, supp[entry['key']], index) %>
+            </div>
+          <% end %>
+        </div>
+      </details>
+    <% end %>
+  <% end %>
+</div>

--- a/app/views/loci/_supplements.html.erb
+++ b/app/views/loci/_supplements.html.erb
@@ -1,0 +1,36 @@
+<% supplements = hash_rows(@locus['supplements']) %>
+<% if supplements.any? %>
+  <div class="ls-card">
+    <h2>Supplements</h2>
+    <p class="text-sm text-[#6a5d4c] mb-4">Additional descriptions recorded later as the locus was further excavated.</p>
+    <% supplements.each_with_index do |supp, i| %>
+      <% stype = supp['supplement_type'].to_s %>
+      <% field_set = supplement_types[stype] %>
+      <div class="card">
+        <div class="card-body">
+          <h3 class="card-title text-xl font-semibold"><%= stype.titleize.presence || "Supplement #{i + 1}" %></h3>
+          <% if supp['supplement_date'].present? || supp['recorder'].present? %>
+            <p class="text-sm text-[#6a5d4c] mb-2">
+              <% if supp['supplement_date'].present? %>Recorded <%= read_date(supp['supplement_date']) %><% end %>
+              <% if supp['recorder'].present? %><%= ' &middot; by '.html_safe if supp['supplement_date'].present? %><%= supp['recorder'] %><% end %>
+            </p>
+          <% end %>
+          <% if field_set && @descriptions[field_set].present? %>
+            <% @descriptions[field_set].each do |section| %>
+              <% rows = section[1].select { |entry| supp[entry['key']].to_s.present? } %>
+              <% if rows.any? %>
+                <h4 class="font-semibold mt-3 mb-1"><%= section[0] %></h4>
+                <% rows.each do |entry| %>
+                  <div class="pl-4 flex mb-1">
+                    <p class="w-80 font-semibold"><%= entry['label'] %>:</p>
+                    <p><%= output(supp[entry['key']], entry['type']) %></p>
+                  </div>
+                <% end %>
+              <% end %>
+            <% end %>
+          <% end %>
+        </div>
+      </div>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/loci/_supplements_form.html.erb
+++ b/app/views/loci/_supplements_form.html.erb
@@ -1,0 +1,51 @@
+<div class="row">
+  <div class="col">
+    <h1 class="text-xl font-bold">Supplements</h1>
+    <p class="text-sm text-[#6a5d4c]">Record an additional description for this locus as it is further excavated. Each supplement reuses the field set for its type.</p>
+  </div>
+</div>
+
+<div id="supplements-container">
+  <% hash_rows(@locus['supplements']).each_with_index do |supp, i| %>
+    <%= render 'supplement_block', supp: supp, index: i, stype: supp['supplement_type'].to_s %>
+  <% end %>
+</div>
+
+<div class="form-row flex flex-wrap items-end gap-2 my-3">
+  <div class="form-group">
+    <label for="supplement-type-select">Add supplement</label>
+    <select id="supplement-type-select" class="form-control">
+      <% supplement_types.each_key do |stype| %>
+        <option value="<%= stype %>"><%= stype.titleize %></option>
+      <% end %>
+    </select>
+  </div>
+  <button type="button" id="add-supplement"
+          class="bg-blue-500 text-white px-3 py-1 rounded hover:bg-blue-600 cursor-pointer">Add</button>
+</div>
+
+<% supplement_types.each_key do |stype| %>
+  <template id="supplement-template-<%= stype %>">
+    <%= render 'supplement_block', supp: {}, index: '__INDEX__', stype: stype %>
+  </template>
+<% end %>
+
+<script>
+  (function () {
+    var container = document.getElementById('supplements-container');
+    var addBtn = document.getElementById('add-supplement');
+    var typeSelect = document.getElementById('supplement-type-select');
+    if (!container || !addBtn || !typeSelect) return;
+
+    // Continue numbering past any server-rendered rows so indices stay unique.
+    var nextIndex = container.querySelectorAll('.supplement-block').length;
+
+    addBtn.addEventListener('click', function () {
+      var tpl = document.getElementById('supplement-template-' + typeSelect.value);
+      if (!tpl) return;
+      var html = tpl.innerHTML.split('__INDEX__').join(String(nextIndex));
+      container.insertAdjacentHTML('beforeend', html);
+      nextIndex += 1;
+    });
+  })();
+</script>

--- a/app/views/loci/_user_photos.html.erb
+++ b/app/views/loci/_user_photos.html.erb
@@ -16,7 +16,7 @@
         </tr>
       </thead>
       <tbody>
-        <% @locus.dig('user_photos').each do |photo| %>
+        <% hash_rows(@locus['user_photos']).each do |photo| %>
           <tr class="hover:bg-amber-100">
             <td class="px-4 py-2 text-left"><%= read_date(photo["taken_at"]) %></td>
             <td class="px-4 py-2 text-left"><%= photo["user_name"].presence || photo["user"] %></td>


### PR DESCRIPTION
## What

### Supplement sheets (new)
- `_supplements.html.erb` was empty — now renders each recorded supplement (type, date, recorder) and its description field-set values.
- New `_supplements_form.html.erb` + `_supplement_block.html.erb`: add/edit/remove supplements in the locus edit form, with a per-type `<template>` cloned by JS. Wired into `_form.html.erb`.
- New `supplement_input_for` helper. A supplement is a flat hash on the locus doc: `{supplement_type, supplement_date, recorder, <description field keys…>}`, posted with explicit indexed param names (`locus[supplements][i][key]`) so different supplement types don't get column-zipped together.

### Legacy-Hash hardening (fixes locus show & edit 500s)
Some old docs store embedded collections (`levels`, `photos`, `user_photos`, `pails`, `readings`, `finds`, `stratigraphies`) as a Hash keyed by id rather than an array. Iterating that yields `[key, value]` pairs and raises `no implicit conversion of String into Integer` (same root cause as the earlier registrar/pottery 500s).

Routed every locus embedded-collection iteration through the existing `hash_rows` helper:
- **Show:** `_levels`, `_photos`, `_user_photos`, `_pottery` (pails + readings), `_stratigraphy`
- **Edit form:** `_levels_form`, `_photos_form`, `_pails_form`, `_pail_form_row` (readings + finds), `_stratigraphy_form`

This was the cause of the reported crash on `/areas/08/squares/92/loci/001/edit` — the edit-form partials had never been hardened.

## Notes
- Mobile counterparts (supplement + stratigraphy add/edit/delete) are implemented separately in od_flutter and ship via the app build.
- `rubocop` clean; all changed ERB compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)