### PR TITLE
Clean up locus dates, form-row clarity, and photo thumbnails

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -99,8 +99,15 @@ module ApplicationHelper
     end
   end
 
+  # Day-granularity dates only — never a timestamp. Renders clearly, e.g.
+  # "24 June, 2026". Falls back to the raw value if it can't be parsed so a bad
+  # date string never 500s a page.
   def read_date(date_string)
-    Date.parse(date_string).strftime('%d %b, %Y') if date_string.present?
+    return if date_string.blank?
+
+    Date.parse(date_string.to_s).strftime('%-d %B, %Y')
+  rescue ArgumentError, TypeError
+    date_string
   end
 
   def output(value, type)

--- a/app/views/finds/index.html.erb
+++ b/app/views/finds/index.html.erb
@@ -44,7 +44,7 @@
         <%= find.pail_number %>
       </div>
       <div class="w-2/12">
-        <%= find.pail_date %>
+        <%= read_date find.pail_date %>
       </div>
       <div class="w-2/12">
         <%= find.type %>

--- a/app/views/loci/_general_form.html.erb
+++ b/app/views/loci/_general_form.html.erb
@@ -69,7 +69,7 @@
 
 <script>
   $(function () {
-    $("#start_date").datepicker({ dateFormat: "dd M, yy" });
-    $("#end_date").datepicker({ dateFormat: "dd M, yy" });
+    $("#start_date").datepicker({ dateFormat: "d MM, yy" });
+    $("#end_date").datepicker({ dateFormat: "d MM, yy" });
   });
 </script>

--- a/app/views/loci/_level_form_row.html.erb
+++ b/app/views/loci/_level_form_row.html.erb
@@ -1,4 +1,8 @@
 <div class="form-row level-row">
+  <div class="repeat-row__head">
+    <p class="repeat-row__title">Level</p>
+    <button name="button" onclick="removeThisLevel(this);" type="button" class="btn btn-danger btn-sm">Remove level</button>
+  </div>
   <div class="form-group col-md-2">
     <%= label_tag "locus[levels[][top_level]]", "Top Level" %>
     <%= text_field_tag "locus[levels[][top_level]]", level['top_level'], class: 'form-control' %>
@@ -14,8 +18,5 @@
     <div class="form-group col-md-3">
     <%= label_tag "locus[levels[][method_bottom]]", "Recorded with" %>
     <%= select_tag "locus[levels[][method_bottom]]", options_for_select(survey_instruments, level['method_bottom']), include_blank: true, class: 'form-control' %>
-  </div>
-  <div class="form-group col-md-2 text-bottom d-flex flex-column">
-    <button name="button" onclick="removeThisLevel(this);" type="button" class="mt-auto btn btn-danger btn-sm">Delete</button>
   </div>
 </div>

--- a/app/views/loci/_levels_form.html.erb
+++ b/app/views/loci/_levels_form.html.erb
@@ -22,29 +22,8 @@
   };
 
   $(function($) {
-    var html = `
-      <div class="form-row level-row">
-        <div class="form-group col-md-2">
-          <%= label_tag "locus[levels[][top_level]]", "Top Level" %>
-          <%= text_field_tag "locus[levels[][top_level]]", '', class: 'form-control' %>
-        </div>
-        <div class="form-group col-md-3">
-          <%= label_tag "locus[levels[][method_top]]", "Recorded with" %>
-          <%= select_tag "locus[levels[][method_top]]", options_for_select(survey_instruments), include_blank: true, class: 'form-control' %>
-        </div>
-        <div class="form-group col-md-2">
-          <%= label_tag "locus[levels[][bottom_level]]", "Bottom Level" %>
-          <%= text_field_tag "locus[levels[][bottom_level]]", '', class: 'form-control' %>
-        </div>
-          <div class="form-group col-md-3">
-          <%= label_tag "locus[levels[][method_bottom]]", "Recorded with" %>
-          <%= select_tag "locus[levels[][method_bottom]]", options_for_select(survey_instruments), include_blank: true, class: 'form-control' %>
-        </div>
-        <div class="form-group col-md-2 text-bottom d-flex flex-column">
-          <button name="button" onclick="removeThisLevel(this);" type="button" class="mt-auto btn btn-danger btn-sm">Delete</button>
-        </div>
-      </div>
-    `
+    // Render the same partial used for existing rows so added rows match.
+    var html = "<%= j render 'level_form_row', level: {} %>"
     var $button = $('#add-level-row')
 
     $button.click(function() {

--- a/app/views/loci/_pail_form_row.html.erb
+++ b/app/views/loci/_pail_form_row.html.erb
@@ -1,4 +1,8 @@
 <div class="form-row pail-row" data-pail-index=<%= index %>>
+  <div class="repeat-row__head">
+    <p class="repeat-row__title">Pail<%= " #{pail['pail_number']}" if pail['pail_number'].present? %></p>
+    <button name="button" onclick="removeThisPail(this);" type="button" class="btn btn-danger btn-sm">Remove pail</button>
+  </div>
   <div class="form-group col-md-2">
     <%= label_tag "locus[pails[#{index}][pail_number]]", "Number" %>
     <%= text_field_tag "locus[pails[#{index}][pail_number]]", pail['pail_number'], class: 'form-control' %>
@@ -27,10 +31,6 @@
   <div class="form-group col-md-10">
     <%= label_tag "locus[pails[#{index}][pottery_comments]]", "Comments" %>
     <%= text_area_tag "locus[pails[#{index}][pottery_comments]]", pail['pottery_comments'], class: 'form-control' %>
-  </div>
-  <div class="form-group col-md-1"></div>
-  <div class="form-group col-md-1 text-bottom d-flex flex-column">
-    <button name="button" onclick="removeThisPail(this);" type="button" class="mt-auto btn btn-danger btn-sm">Delete</button>
   </div>
   <div class="col">
     <div class="row">

--- a/app/views/loci/_photo_form_row.html.erb
+++ b/app/views/loci/_photo_form_row.html.erb
@@ -1,4 +1,8 @@
 <div class="form-row photo-row" data-photo-index=<%= index %>>
+  <div class="repeat-row__head">
+    <p class="repeat-row__title">Photo<%= " #{photo['number']}" if photo['number'].present? %></p>
+    <button name="button" onclick="removeThisPhoto(this);" type="button" class="btn btn-danger btn-sm">Remove photo</button>
+  </div>
   <div class="form-group col-md-3">
     <%= label_tag "locus[photos[#{index}][date]]", "Date" %>
     <%= text_field_tag "locus[photos[#{index}][date]]", read_date(photo['date']), class: 'form-control' %>
@@ -11,13 +15,10 @@
     <%= label_tag "locus[photos[#{index}][subject]]", "Subject" %>
     <%= text_field_tag "locus[photos[#{index}][subject]]", photo['subject'], class: 'form-control' %>
   </div>
-  <div class="form-group col-md-2 text-bottom d-flex flex-column">
-    <button name="button" onclick="removeThisPhoto(this);" type="button" class="mt-auto btn btn-danger btn-sm">Delete</button>
-  </div>
 </div>
 
 <script>
   $( "#locus_photos_<%= index %>_date" ).datepicker({
-    dateFormat: "dd M, yy"
+    dateFormat: "d MM, yy"
   });
 </script>

--- a/app/views/loci/_photos.html.erb
+++ b/app/views/loci/_photos.html.erb
@@ -16,7 +16,9 @@
             # Convention-named/bulk photos reference an S3 key; legacy daily
             # photos reference a number.
             medium = photo["key"].present? ? Photo.url_for_key(photo["key"], :medium) : Photo.photo_url(photo["number"], :medium)
-            thumb  = photo["key"].present? ? Photo.url_for_key(photo["key"], :thumb)  : Photo.photo_url(photo["number"], :thumb)
+            # `preview` (600px, fit) instead of `thumb` (100px): the grid renders
+            # these at ~128px and 2x on hi-DPI, so a 100px thumb looks blurry.
+            thumb  = photo["key"].present? ? Photo.url_for_key(photo["key"], :preview) : Photo.photo_url(photo["number"], :preview)
           %>
           <tr class="hover:bg-gray-200">
             <td class="px-4 py-2 text-left"><%= read_date photo["date"] %></td>

--- a/app/views/loci/_stratigraphy_form.html.erb
+++ b/app/views/loci/_stratigraphy_form.html.erb
@@ -30,29 +30,8 @@
   };
 
   $(function($) {
-    var html = `
-    <div class="form-row stratigraphy-row">
-      <div class="form-group col-md-3">
-        <%= label_tag "locus[stratigraphies[][is_related]]", "How is it related?" %>
-        <%= select_tag "locus[stratigraphies[][is_related]]", options_for_select(stratigraphic_relationships), include_blank: true, class: 'form-control' %>
-      </div>
-      <div class="form-group col-md-3">
-        <%= label_tag "locus[stratigraphies[][related]]", "What is it related to?" %>
-        <%= select_tag "locus[stratigraphies[][related]]", options_for_select(stratigraphy_relatation_types), include_blank: true, class: 'form-control' %>
-      </div>
-      <div class="form-group col-md-3">
-        <%= label_tag "locus[stratigraphies[][related_locus]]", "Related Locus" %>
-        <%= select_tag "locus[stratigraphies[][related_locus]]", options_for_select(all_loci), include_blank: true, class: 'form-control' %>
-      </div>
-      <div class="form-group col-md-3 text-bottom d-flex flex-column">
-        <button name="button" onclick="removeThis(this);" type="button" class="mt-auto btn btn-danger btn-sm">Delete</button>
-      </div>
-    </div>
-    `
-
-   function removeThis(_this){
-        $(_this).parents('.stratigraphy-row').remove();
-    };
+    // Render the same partial used for existing rows so added rows match.
+    var html = "<%= j render 'stratigraphy_form_row', stratigraphy: {} %>"
 
     var $button = $('#add-row')
 

--- a/app/views/loci/_stratigraphy_form_row.html.erb
+++ b/app/views/loci/_stratigraphy_form_row.html.erb
@@ -1,4 +1,8 @@
 <div class="form-row stratigraphy-row">
+  <div class="repeat-row__head">
+    <p class="repeat-row__title">Relationship</p>
+    <button name="button" onclick="removeThis(this);" type="button" class="btn btn-danger btn-sm">Remove relationship</button>
+  </div>
   <div class="form-group col-md-3">
     <%= label_tag "locus[stratigraphies[][is_related]]", "How is it related?" %>
     <%= select_tag "locus[stratigraphies[][is_related]]", options_for_select(stratigraphic_relationships, stratigraphy['is_related']), include_blank: true, class: 'form-control' %>
@@ -10,8 +14,5 @@
   <div class="form-group col-md-3">
     <%= label_tag "locus[stratigraphies[][related_locus]]", "Related Locus" %>
     <%= select_tag "locus[stratigraphies[][related_locus]]", options_for_select(all_loci, sanitize_locus(stratigraphy['related_locus'])), include_blank: true, class: 'form-control' %>
-  </div>
-  <div class="form-group col-md-3 text-bottom d-flex flex-column">
-    <button name="button" onclick="removeThis(this);" type="button" class="mt-auto btn btn-danger btn-sm">Delete</button>
   </div>
 </div>

--- a/app/views/loci/_user_photos.html.erb
+++ b/app/views/loci/_user_photos.html.erb
@@ -23,7 +23,7 @@
             <td class="px-4 py-2 text-left"><%= photo["subject"] %></td>
             <td class="px-4 py-2 text-center">
               <a class="locus-photo-link flex justify-center" href="<%= Photo.url_for_key(photo["key"], :medium) %>" data-lightbox="locus-field-photos">
-                <img class="locus-photo w-32 h-32 object-cover rounded" src="<%= Photo.url_for_key(photo["key"], :thumb) %>" alt="" />
+                <img class="locus-photo w-32 h-32 object-cover rounded" src="<%= Photo.url_for_key(photo["key"], :preview) %>" alt="" />
               </a>
             </td>
           </tr>

--- a/app/views/pails/index.html.erb
+++ b/app/views/pails/index.html.erb
@@ -36,7 +36,7 @@
         <%= link_to "#{pail.locus}", area_square_locus_path(@area, @square, pail.locus), class: "text-blue-500 hover:text-blue-700" %>
       </div>
       <div class="w-6/12">
-        <%= pail.pail_date %>
+        <%= read_date pail.pail_date %>
       </div>
     </div>
   <% end %>

--- a/app/views/shared/_edit_form_theme.html.erb
+++ b/app/views/shared/_edit_form_theme.html.erb
@@ -48,10 +48,18 @@
   .od-form .col-md-3 { flex: 1 1 11rem; }
   .od-form .form-row .form-group, .od-form .row .form-group { margin-bottom: 0; }
 
-  /* Repeatable rows become tidy inner cards */
+  /* Repeatable rows become tidy inner cards, each with a labelled header so it
+     is always clear which item a Remove button belongs to. */
   .od-form .stratigraphy-row, .od-form .level-row, .od-form .photo-row, .od-form .pail-row {
     display: flex; flex-wrap: wrap; gap: 1rem; align-items: flex-end;
     background: #fff; border: 1px solid #e7dcc4; border-radius: 0.7rem; padding: 1rem; margin-bottom: 0.85rem;
+  }
+  .od-form .repeat-row__head {
+    flex: 0 0 100%; display: flex; align-items: center; justify-content: space-between;
+    gap: 1rem; padding-bottom: 0.6rem; border-bottom: 1px dashed #e7dcc4;
+  }
+  .od-form .repeat-row__title {
+    font-family: 'Spectral', serif; font-weight: 600; color: #2a231b; font-size: 0.95rem; margin: 0;
   }
 
   /* Choice chips (radios) */

--- a/spec/views/loci/_user_photos.html.erb_spec.rb
+++ b/spec/views/loci/_user_photos.html.erb_spec.rb
@@ -21,8 +21,8 @@ RSpec.describe 'loci/_user_photos', type: :view do
     expect(rendered).to match(/Unofficial/i)
     expect(rendered).to include('Field Lead')   # uploader attribution
     expect(rendered).to include('north baulk')  # subject
-    expect(rendered).to include('19 Jun, 2026') # read_date(taken_at)
-    expect(rendered).to include('https://img.test/balua/user_photos/L1-u8-20260619T143355Z-3b9c.jpg/thumb')
+    expect(rendered).to include('19 June, 2026') # read_date(taken_at)
+    expect(rendered).to include('https://img.test/balua/user_photos/L1-u8-20260619T143355Z-3b9c.jpg/preview')
   end
 
   it 'falls back to the user id when no display name is recorded' do


### PR DESCRIPTION
## Dates — day-granularity, clearly formatted
- `read_date` now renders **"24 June, 2026"** (full month, no leading-zero day, never a timestamp) and falls back to the raw string instead of 500-ing on an unparseable date.
- Routed the two raw `pail_date` displays (`pails/index`, `finds/index`) through it.
- Aligned the jQuery datepickers (start/end date, photo date) to `d MM, yy` so edited values round-trip with the displayed format.
- Everything else already flows through `read_date`, so it picks up the format automatically.

## Locus edit forms — self-explanatory rows
- Level / photo / stratigraphy / pail rows now have a labelled header bar (item name + a clear **Remove level/photo/relationship/pail** button) instead of an ambiguous "Delete" floating at the end of a wrapping row. Themed in the shared edit-form stylesheet.
- DRY'd the **Add level** / **Add relationship** buttons to render the row partials, so newly-added rows match existing ones exactly.

## Photo thumbnails
- Locus show page (official + field photos) now uses the 600px `preview` imgproxy style instead of the 100px `thumb`, which was upscaled and blurry at the ~128px (and hi-DPI 2×) display size. Lightbox still opens the larger medium image.

`rubocop` clean; all changed ERB compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)