### PR TITLE
Strip timestamps from pail and find dates in the locus edit form

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -195,7 +195,8 @@ module ApplicationHelper
     when 'text_field'
       text_field_tag full_param_name.to_s, value, class: 'form-control'
     when 'date'
-      text_field_tag full_param_name.to_s, value, class: 'form-control'
+      # Day-granularity only: strip any stored timestamp to a clean date.
+      text_field_tag full_param_name.to_s, read_date(value), class: 'form-control'
     when 'checkbox'
       check_box_tag full_param_name.to_s, true, false, class: 'form-control'
     when 'text_area'

--- a/app/views/loci/_pail_find_form_row.html.erb
+++ b/app/views/loci/_pail_find_form_row.html.erb
@@ -16,6 +16,7 @@
   function removeThisPail<%= pail_index %>Find(_this){
     $(_this).parents('.pail-<%= pail_index %>-find-row').remove();
   };
+  $( "#locus_pails_<%= pail_index %>_finds_<%= find_index %>_date" ).datepicker({ dateFormat: "d MM, yy" });
   $( "#locus_pails_<%= pail_index %>_finds_<%= find_index %>_pot_form" ).autocomplete({
     source: potFormValues,
     minLength: 0,

--- a/app/views/loci/_pail_form_row.html.erb
+++ b/app/views/loci/_pail_form_row.html.erb
@@ -9,7 +9,7 @@
   </div>
   <div class="form-group col-md-2">
     <%= label_tag "locus[pails[#{index}][pail_date]]", "Date" %>
-    <%= text_field_tag "locus[pails[#{index}][pail_date]]", pail['pail_date'], class: 'form-control' %>
+    <%= text_field_tag "locus[pails[#{index}][pail_date]]", read_date(pail['pail_date']), class: 'form-control' %>
   </div>
   <div class="form-group col-md-2">
     <%= label_tag "locus[pails[#{index}][baskets]]", "Baskets" %>
@@ -65,6 +65,8 @@
 <script>
 
   $(function($) {
+    $("#locus_pails_<%= index %>_pail_date").datepicker({ dateFormat: "d MM, yy" });
+
     var nextPailReadingIndex = $('.pail-<%= index %>-reading-row').last().data('pail-<% index %>-reading-index') + 1
 
     var html = "<%= j render 'pail_reading_form_row', pail: pail, reading: {}, pail_index: index, reading_index: 'TEMPREADINGROW' %>".replace('TEMPREADINGROW', nextPailReadingIndex)


### PR DESCRIPTION
The pail **Date** and each find's **Date** in the locus edit form were rendered straight from storage, where the mobile app writes full ISO timestamps (e.g. `2026-06-22T10:55:38.7…`).

- Render both through `read_date`, so they display day-granularity only (**"22 June, 2026"**) and are saved back clean (touching/saving the locus normalizes the stored value).
- Attach the jQuery datepicker (`d MM, yy`) to the pail-date and find-date inputs, matching the photo/start/end date fields.

Find dates go through the shared `input_with_full_param_name` `date` branch, so any other date field rendered that way benefits too.

`rubocop` clean; ERB compiles; datepicker element IDs verified against Rails' id sanitization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)