### PR TITLE
Use native date inputs on locus forms (drop unstyled jQuery datepicker)

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -110,6 +110,17 @@ module ApplicationHelper
     date_string
   end
 
+  # Normalize any stored date or timestamp to YYYY-MM-DD for a native
+  # <input type="date">. Returns '' when unparseable so the picker isn't left in
+  # a broken state.
+  def iso_date(date_string)
+    return '' if date_string.blank?
+
+    Date.parse(date_string.to_s).strftime('%Y-%m-%d')
+  rescue ArgumentError, TypeError
+    ''
+  end
+
   def output(value, type)
     case type
     when 'date'
@@ -195,8 +206,8 @@ module ApplicationHelper
     when 'text_field'
       text_field_tag full_param_name.to_s, value, class: 'form-control'
     when 'date'
-      # Day-granularity only: strip any stored timestamp to a clean date.
-      text_field_tag full_param_name.to_s, read_date(value), class: 'form-control'
+      # Native date picker; day-granularity only (strips any stored timestamp).
+      text_field_tag full_param_name.to_s, iso_date(value), type: 'date', class: 'form-control'
     when 'checkbox'
       check_box_tag full_param_name.to_s, true, false, class: 'form-control'
     when 'text_area'

--- a/app/views/loci/_general_form.html.erb
+++ b/app/views/loci/_general_form.html.erb
@@ -24,11 +24,11 @@
   </div>
   <div>
     <label for="start_date">Start Date</label>
-    <input type="text" id="start_date" name="locus[start_date]" value="<%= read_date @locus['start_date'] %>" autocomplete="off">
+    <input type="date" id="start_date" name="locus[start_date]" value="<%= iso_date @locus['start_date'] %>" autocomplete="off">
   </div>
   <div>
     <label for="end_date">End Date</label>
-    <input type="text" id="end_date" name="locus[end_date]" value="<%= read_date @locus['end_date'] %>" autocomplete="off">
+    <input type="date" id="end_date" name="locus[end_date]" value="<%= iso_date @locus['end_date'] %>" autocomplete="off">
   </div>
 </div>
 
@@ -66,10 +66,3 @@
     <% end %>
   </div>
 </div>
-
-<script>
-  $(function () {
-    $("#start_date").datepicker({ dateFormat: "d MM, yy" });
-    $("#end_date").datepicker({ dateFormat: "d MM, yy" });
-  });
-</script>

--- a/app/views/loci/_pail_find_form_row.html.erb
+++ b/app/views/loci/_pail_find_form_row.html.erb
@@ -16,7 +16,6 @@
   function removeThisPail<%= pail_index %>Find(_this){
     $(_this).parents('.pail-<%= pail_index %>-find-row').remove();
   };
-  $( "#locus_pails_<%= pail_index %>_finds_<%= find_index %>_date" ).datepicker({ dateFormat: "d MM, yy" });
   $( "#locus_pails_<%= pail_index %>_finds_<%= find_index %>_pot_form" ).autocomplete({
     source: potFormValues,
     minLength: 0,

--- a/app/views/loci/_pail_form_row.html.erb
+++ b/app/views/loci/_pail_form_row.html.erb
@@ -9,7 +9,7 @@
   </div>
   <div class="form-group col-md-2">
     <%= label_tag "locus[pails[#{index}][pail_date]]", "Date" %>
-    <%= text_field_tag "locus[pails[#{index}][pail_date]]", read_date(pail['pail_date']), class: 'form-control' %>
+    <%= text_field_tag "locus[pails[#{index}][pail_date]]", iso_date(pail['pail_date']), type: 'date', class: 'form-control' %>
   </div>
   <div class="form-group col-md-2">
     <%= label_tag "locus[pails[#{index}][baskets]]", "Baskets" %>
@@ -65,8 +65,6 @@
 <script>
 
   $(function($) {
-    $("#locus_pails_<%= index %>_pail_date").datepicker({ dateFormat: "d MM, yy" });
-
     var nextPailReadingIndex = $('.pail-<%= index %>-reading-row').last().data('pail-<% index %>-reading-index') + 1
 
     var html = "<%= j render 'pail_reading_form_row', pail: pail, reading: {}, pail_index: index, reading_index: 'TEMPREADINGROW' %>".replace('TEMPREADINGROW', nextPailReadingIndex)

--- a/app/views/loci/_photo_form_row.html.erb
+++ b/app/views/loci/_photo_form_row.html.erb
@@ -5,7 +5,7 @@
   </div>
   <div class="form-group col-md-3">
     <%= label_tag "locus[photos[#{index}][date]]", "Date" %>
-    <%= text_field_tag "locus[photos[#{index}][date]]", read_date(photo['date']), class: 'form-control' %>
+    <%= text_field_tag "locus[photos[#{index}][date]]", iso_date(photo['date']), type: 'date', class: 'form-control' %>
   </div>
   <div class="form-group col-md-3">
     <%= label_tag "locus[photos[#{index}][number]]", "Number" %>
@@ -16,9 +16,3 @@
     <%= text_field_tag "locus[photos[#{index}][subject]]", photo['subject'], class: 'form-control' %>
   </div>
 </div>
-
-<script>
-  $( "#locus_photos_<%= index %>_date" ).datepicker({
-    dateFormat: "d MM, yy"
-  });
-</script>

--- a/app/views/loci/_supplement_block.html.erb
+++ b/app/views/loci/_supplement_block.html.erb
@@ -10,7 +10,7 @@
   <div class="form-row flex flex-wrap gap-3 mb-2">
     <div class="form-group">
       <label>Date</label>
-      <input type="date" name="locus[supplements][<%= index %>][supplement_date]" value="<%= supp['supplement_date'] %>" class="form-control">
+      <input type="date" name="locus[supplements][<%= index %>][supplement_date]" value="<%= iso_date(supp['supplement_date']) %>" class="form-control">
     </div>
     <div class="form-group">
       <label>Recorder</label>


### PR DESCRIPTION
The jQuery UI datepicker was rendering with no theme CSS — it dumped the calendar inline and overlapped the form fields. Rather than wire up jQuery UI's stylesheet, replace every locus-form date field with a native `<input type="date">`:

- **start date, end date** (general form), **pail date**, **find date** (via `input_with_full_param_name`), **photo date**, and the **supplement date**.
- Removed all the now-unused `.datepicker()` init scripts.
- The `.od-form` theme already styles `input[type="date"]`, so they match the rest of the form.

Native date inputs require `YYYY-MM-DD` values, so added an `iso_date` helper that normalizes any stored date or timestamp to `YYYY-MM-DD` (returns `''` if unparseable so the picker isn't left broken). `read_date` still handles the clear day-granularity display ("22 June, 2026") on show pages. On save, dates are stored as clean `YYYY-MM-DD`.

`rubocop` clean; all changed ERB compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)