### PR TITLE
Fix pottery reading Add button and pottery summary display

### DIFF
--- a/app/views/loci/_pail_form_row.html.erb
+++ b/app/views/loci/_pail_form_row.html.erb
@@ -65,7 +65,8 @@
 <script>
 
   $(function($) {
-    var nextPailReadingIndex = $('.pail-<%= index %>-reading-row').last().data('pail-<% index %>-reading-index') + 1
+    var lastReadingIndex = $('.pail-<%= index %>-reading-row').last().data('pail-<%= index %>-reading-index')
+    var nextPailReadingIndex = (lastReadingIndex === undefined ? -1 : Number(lastReadingIndex)) + 1
 
     var html = "<%= j render 'pail_reading_form_row', pail: pail, reading: {}, pail_index: index, reading_index: 'TEMPREADINGROW' %>".replace('TEMPREADINGROW', nextPailReadingIndex)
 

--- a/app/views/loci/_pottery.html.erb
+++ b/app/views/loci/_pottery.html.erb
@@ -38,7 +38,8 @@
                   <h3 class="text-lg font-semibold mb-2">Age: <%= age %></h3>
                   <ul class="list-disc ml-6">
                     <% readings.each do |reading| %>
-                      <li><%= reading["reading_data"] %></li>
+                      <% summary = [reading["count"], reading["quantity_modifier"], reading["time_level"], reading["pot_form"], reading["question"]].map(&:presence).compact.join(' ') %>
+                      <li><%= summary.presence || '—' %></li>
                     <% end %>
                   </ul>
                 </td>


### PR DESCRIPTION
Two pottery-reading bugs in the locus views:

- **Add Reading button broken (2nd+ readings):** `_pail_form_row.html.erb` computed the next reading index from a data attribute selected with `<% index %>` (missing the `=`), so the selector was literally `pail--reading-index`, `.data(...)` returned `undefined`, and `undefined + 1 = NaN`. Fixed the interpolation and made it default to `0` when a pail has no readings yet.
- **Empty pottery bullets:** `_pottery.html.erb` displayed `reading['reading_data']` — a field that's never captured or saved — so every bullet was blank. Now composes a readable summary from the real fields (`count`, `quantity_modifier`, `time_level`, `pot_form`, `question`).

Display, edit-row rendering, and the `repair_nested_params` save path were already correct.

The mobile side (full add/edit/delete of pottery readings, previously a read-only stub) is implemented in od_flutter and ships with the app build.

ERB compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)