### PR TITLE
Registrar: discard a find (return to field) with a recorded reason

### DIFF
--- a/app/controllers/registrar_controller.rb
+++ b/app/controllers/registrar_controller.rb
@@ -1,8 +1,8 @@
 class RegistrarController < ApplicationController
   # Supervisors may read the registrar; only registrar/dig_director/superuser may write.
   before_action :require_registrar_read
-  before_action :require_registrar_write, only: %i[new create edit update destroy]
-  before_action :set_item, only: [:show, :edit, :update]
+  before_action :require_registrar_write, only: %i[new create edit update destroy discard restore]
+  before_action :set_item, only: %i[show edit update discard restore]
 
   def index
     # Seasons present in the data, plus the current one so a new season is
@@ -46,6 +46,47 @@ class RegistrarController < ApplicationController
     end
   end
 
+  # Discard a find the registrar decided is not a find: it's returned to the
+  # field with a recorded reason. The find stays on the board in the Discarded
+  # stage rather than being deleted, so the decision is auditable.
+  def discard
+    reason = params[:discard_reason].to_s.strip
+    if reason.blank?
+      redirect_to registrar_path(**find_path_params),
+                  alert: 'Please provide a reason for discarding this find.'
+      return
+    end
+
+    @find.merge!(
+      'state' => Registrar::DISCARDED_STATE,
+      'discard_reason' => reason,
+      'discarded_at' => Time.current.iso8601,
+      'discarded_by' => current_user&.email
+    )
+
+    if @doc.save
+      redirect_to registrar_index_path(season: params[:season]),
+                  notice: "Find ##{@find['field_number']} discarded and returned to the field."
+    else
+      redirect_to registrar_path(**find_path_params), alert: 'Something went wrong discarding the find.'
+    end
+  end
+
+  # Undo a discard: the find returns to Incoming and the discard metadata is
+  # cleared, so a mistaken discard isn't a dead end.
+  def restore
+    @find.merge!('state' => Registrar::RESTORED_STATE)
+    @find.delete('discard_reason')
+    @find.delete('discarded_at')
+    @find.delete('discarded_by')
+
+    if @doc.save
+      redirect_to registrar_path(**find_path_params), notice: 'Find restored to Incoming.'
+    else
+      redirect_to registrar_path(**find_path_params), alert: 'Something went wrong restoring the find.'
+    end
+  end
+
   def set_item
     @item_id = params[:id]
     @item_number = params[:item_number].to_s
@@ -62,6 +103,11 @@ class RegistrarController < ApplicationController
     return if @find
 
     redirect_to registrar_index_path, alert: 'That find could not be located.'
+  end
+
+  # The composite params that identify a find across registrar routes.
+  def find_path_params
+    { id: @item_id, pail_id: @pail_id, item_number: @item_number, item_locus_code: @item_locus_code }
   end
 
   # Coerce an embedded collection (pails, finds) into an array of hashes. Some

--- a/app/models/registrar.rb
+++ b/app/models/registrar.rb
@@ -9,8 +9,15 @@ class Registrar
     { key: 'incoming',  label: 'Incoming',             states: %w[unregistered] },
     { key: 'initial',   label: 'Initial Registration', states: ['initial registration'] },
     { key: 'pending',   label: 'Pending Approval',     states: %w[WIP] },
-    { key: 'completed', label: 'Completed',            states: ['registrarion complete'] }
+    { key: 'completed', label: 'Completed',            states: ['registrarion complete'] },
+    # Finds the registrar decided are not finds: returned to the field with a
+    # recorded reason. Kept on the board (not deleted) for the record.
+    { key: 'discarded', label: 'Discarded',            states: %w[discarded] }
   ].freeze
+
+  # The state a discarded find carries, and the one it returns to when restored.
+  DISCARDED_STATE = 'discarded'.freeze
+  RESTORED_STATE = 'unregistered'.freeze
 
   def initialize(row_values)
     @area, @square, @code, @pail_number, @field_number, @registration_number, @type, @remarks, @state, @id = row_values

--- a/app/views/registrar/show.html.erb
+++ b/app/views/registrar/show.html.erb
@@ -7,16 +7,63 @@
     <span class="text-[#2a231b]">Pail <%= @pail_id %></span>
   </nav>
 
-  <div class="flex flex-wrap items-end justify-between gap-4 mb-6">
+  <% discarded = @find['state'] == Registrar::DISCARDED_STATE %>
+  <div class="flex flex-wrap items-end justify-between gap-4 mb-6" x-data="{ discardOpen: false }">
     <div>
       <h1 class="font-serif text-4xl text-[#2a231b]">Field Find #<%= @find['field_number'] %></h1>
       <p class="text-[#6a5d4c] mt-1">Locus <%= @area %>.<%= @square %>.<%= @locus_code %> &middot; Pail <%= @pail_id %></p>
     </div>
     <% if current_user&.can_edit_registrar? %>
-      <%= link_to "Edit find", edit_registrar_path(id: @item_id, pail_id: @pail_id, item_number: @item_number, item_locus_code: @item_locus_code),
-                  class: "inline-flex items-center rounded-full bg-[#b1542b] px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-[#8d3f1d]" %>
+      <div class="flex flex-wrap items-center gap-2">
+        <% if discarded %>
+          <%= button_to "Restore to Incoming", restore_registrar_path(id: @item_id, pail_id: @pail_id, item_number: @item_number, item_locus_code: @item_locus_code),
+                        method: :patch,
+                        class: "inline-flex items-center rounded-full border border-[#ddcfb4] px-4 py-2 text-sm font-medium text-[#6a5d4c] hover:border-[#c8a87f] hover:text-[#b1542b] cursor-pointer" %>
+        <% else %>
+          <%= link_to "Edit find", edit_registrar_path(id: @item_id, pail_id: @pail_id, item_number: @item_number, item_locus_code: @item_locus_code),
+                      class: "inline-flex items-center rounded-full bg-[#b1542b] px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-[#8d3f1d]" %>
+          <button type="button" @click="discardOpen = true"
+                  class="inline-flex items-center rounded-full border border-[#d8a99a] px-4 py-2 text-sm font-medium text-[#9c2a1c] hover:bg-[#fdecea] cursor-pointer">
+            Discard find
+          </button>
+        <% end %>
+      </div>
+
+      <%# Discard modal: requires a reason before the find is returned to the field. %>
+      <div x-show="discardOpen" x-cloak style="display:none"
+           @click="discardOpen = false" @keydown.escape.window="discardOpen = false"
+           class="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4">
+        <div @click.stop class="w-full max-w-md rounded-xl border border-[#ddcfb4] bg-[#fbf6ec] p-6 shadow-xl">
+          <h2 class="font-serif text-2xl text-[#2a231b] mb-1">Discard this find?</h2>
+          <p class="text-sm text-[#6a5d4c] mb-4">It will be returned to the field and moved to the Discarded stage. Please record why.</p>
+          <%= form_with(url: discard_registrar_path(id: @item_id, pail_id: @pail_id, item_number: @item_number, item_locus_code: @item_locus_code), method: :patch, local: true) do %>
+            <textarea name="discard_reason" rows="4" required
+                      placeholder="Reason for discarding (e.g. natural stone, modern intrusion)…"
+                      class="w-full rounded-md border border-[#ddcfb4] bg-white px-3 py-2 text-sm text-[#2a231b] focus:border-[#9c6b3f] focus:outline-none"></textarea>
+            <div class="mt-4 flex justify-end gap-2">
+              <button type="button" @click="discardOpen = false"
+                      class="inline-flex items-center rounded-full border border-[#ddcfb4] px-4 py-2 text-sm font-medium text-[#6a5d4c] hover:border-[#c8a87f] hover:text-[#b1542b] cursor-pointer">Cancel</button>
+              <%= submit_tag "Discard find",
+                             class: "inline-flex items-center rounded-full bg-[#9c2a1c] px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-[#7a1f15] cursor-pointer border-0" %>
+            </div>
+          <% end %>
+        </div>
+      </div>
     <% end %>
   </div>
+
+  <% if discarded %>
+    <div class="mb-6 rounded-xl border border-[#e0c9a0] bg-[#fcf3e0] p-4">
+      <p class="font-serif text-lg text-[#8d3f1d] mb-1">Discarded &middot; returned to the field</p>
+      <% if @find['discard_reason'].present? %>
+        <p class="text-sm text-[#6a5d4c]"><span class="font-medium">Reason:</span> <%= @find['discard_reason'] %></p>
+      <% end %>
+      <p class="text-xs text-[#9c8e78] mt-1">
+        <%= "by #{@find['discarded_by']}" if @find['discarded_by'].present? %>
+        <%= "on #{read_date(@find['discarded_at'])}" if @find['discarded_at'].present? %>
+      </p>
+    </div>
+  <% end %>
 
   <div class="grid grid-cols-1 lg:grid-cols-3 gap-6 mb-6">
     <div class="lg:col-span-2 rounded-xl border border-[#ddcfb4] bg-[#fbf6ec] p-6">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,7 +32,12 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :registrar
+  resources :registrar do
+    member do
+      patch :discard
+      patch :restore
+    end
+  end
   resources :bulk_uploads, only: %i[new create]
 
   # Bulk locus-photo association (parse convention-named photos -> suggest loci).

--- a/spec/controllers/registrar_controller_spec.rb
+++ b/spec/controllers/registrar_controller_spec.rb
@@ -70,6 +70,67 @@ RSpec.describe RegistrarController, type: :controller do
     end
   end
 
+  describe 'PATCH discard' do
+    let(:item) { { 'field_number' => '1', 'state' => 'unregistered' } }
+    let(:doc) do
+      d = { 'pails' => [{ 'pail_number' => '1', 'finds' => [item] }] }
+      def d.save = true
+      d
+    end
+    let(:params) { { id: 'doc1', pail_id: '1', item_number: '1', item_locus_code: '1.1.001' } }
+
+    before { allow(db).to receive(:get).with('doc1').and_return(doc) }
+
+    it 'discards with a reason and records metadata' do
+      session[:user_id] = users[:registrar].id
+      patch :discard, params: params.merge(discard_reason: 'modern intrusion')
+      expect(item['state']).to eq('discarded')
+      expect(item['discard_reason']).to eq('modern intrusion')
+      expect(item['discarded_by']).to eq(users[:registrar].email)
+      expect(item['discarded_at']).to be_present
+      expect(response).to redirect_to(registrar_index_path)
+    end
+
+    it 'requires a reason' do
+      session[:user_id] = users[:registrar].id
+      patch :discard, params: params.merge(discard_reason: '   ')
+      expect(item['state']).to eq('unregistered')
+      expect(response).to redirect_to(registrar_path(**params))
+    end
+
+    it 'forbids a read-only area supervisor' do
+      session[:user_id] = users[:area_supervisor].id
+      patch :discard, params: params.merge(discard_reason: 'x')
+      expect(response).to redirect_to(controller.root_path)
+      expect(item['state']).to eq('unregistered')
+    end
+  end
+
+  describe 'PATCH restore' do
+    let(:item) do
+      { 'field_number' => '1', 'state' => 'discarded', 'discard_reason' => 'oops',
+        'discarded_by' => 'r@example.com', 'discarded_at' => '2026-06-26T00:00:00Z' }
+    end
+    let(:doc) do
+      d = { 'pails' => [{ 'pail_number' => '1', 'finds' => [item] }] }
+      def d.save = true
+      d
+    end
+    let(:params) { { id: 'doc1', pail_id: '1', item_number: '1', item_locus_code: '1.1.001' } }
+
+    before { allow(db).to receive(:get).with('doc1').and_return(doc) }
+
+    it 'restores to incoming and clears the discard metadata' do
+      session[:user_id] = users[:registrar].id
+      patch :restore, params: params
+      expect(item['state']).to eq('unregistered')
+      expect(item).not_to have_key('discard_reason')
+      expect(item).not_to have_key('discarded_by')
+      expect(item).not_to have_key('discarded_at')
+      expect(response).to redirect_to(registrar_path(**params))
+    end
+  end
+
   describe 'GET edit (write access)' do
     let(:params) { { id: 'doc1', pail_id: '1', item_number: '1', item_locus_code: '1.1.001' } }
 

--- a/spec/models/registrar_spec.rb
+++ b/spec/models/registrar_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe Registrar, type: :model do
       expect(find_with('initial registration').stage).to eq('initial')
       expect(find_with('WIP').stage).to eq('pending')
       expect(find_with('registrarion complete').stage).to eq('completed')
+      expect(find_with('discarded').stage).to eq('discarded')
     end
 
     it 'falls back to the first stage for an unrecognised state' do


### PR DESCRIPTION
A registrar can now **discard** a find that's decided not to be a find — it's returned to the field, with a required reason recorded.

## Behaviour
- New **Discarded** pipeline stage. Discarded finds stay on the board (not deleted) so the decision is auditable and counted in the pipeline.
- On a find's page, registrars see a **Discard find** button that opens a modal requiring a reason before discarding.
- A discarded find shows a banner (reason + who/when) and a **Restore to Incoming** button instead of Edit/Discard, so a mistaken discard isn't a dead end.

## Implementation
- `Registrar::STAGES` gains `discarded` (state `discarded`); added `DISCARDED_STATE` / `RESTORED_STATE` constants.
- Routes: `PATCH /registrar/:id/discard` and `/restore` (member), gated by `require_registrar_write`; `set_item` extended to cover them.
- `discard` requires a non-blank reason and stores `discard_reason`, `discarded_at`, `discarded_by` on the find hash (in-place merge + `@doc.save`, same path as `update`). `restore` sets state back to `unregistered` and clears the discard metadata.
- Discard modal reuses the app's Alpine backdrop pattern (click-out / Esc to close).

## Tests
- Controller specs: discard success + metadata, reason-required redirect, forbidden for read-only area supervisor; restore clears metadata.
- Model spec: `discarded` state maps to the `discarded` stage.

`rubocop` clean across app + specs; ERB compiles; routes verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)