### PR TITLE
Add pails:audit / pails:fix rake tasks for bad (>=900) pail numbers

### DIFF
--- a/lib/tasks/pails.rake
+++ b/lib/tasks/pails.rake
@@ -1,0 +1,160 @@
+# "Bad" pails are pails numbered 900 or above — placeholders / junk that crept
+# into the data. They live nested in loci docs (locus.pails[]).
+#
+# Two tasks, both scoped to one project + area + square:
+#
+#   # Read-only report + per-pail suggestion (DELETE empties, RENUMBER the rest):
+#   RAILS_ENV=production bin/rails 'pails:audit[baluademo,25,61]'
+#
+#   # Apply the suggested fix — DRY RUN by default; set APPLY=1 to actually save:
+#   RAILS_ENV=production bin/rails 'pails:fix[baluademo,25,61]'
+#   RAILS_ENV=production APPLY=1 bin/rails 'pails:fix[baluademo,25,61]'
+#
+# Policy (matches the agreed default): a bad pail with NO finds and NO readings
+# is DELETED; a bad pail that holds data is RENUMBERED to the next free number in
+# the square (max existing good number + 1, incrementing). Review the audit first.
+namespace :pails do
+  # Pail numbers at or above this are "bad" (placeholders / junk).
+  def bad_pail_threshold = 900
+
+  # Some legacy docs store embedded collections as a Hash keyed by index instead
+  # of an array; coerce both to an array of hashes.
+  def embedded_rows(collection)
+    rows = collection.is_a?(Hash) ? collection.values : collection
+    Array(rows).select { |row| row.is_a?(Hash) }
+  end
+
+  # Gather, for one square: the bad pails (>= threshold) with their host doc, and
+  # the set of "good" integer pail numbers already in use (to pick renumber
+  # targets). Returns [bad, good_numbers].
+  def scan_square(db, area, square)
+    rows = db.view('opendig/loci', reduce: false,
+                                   start_key: [area, square],
+                                   end_key: [area, square, {}])['rows']
+    ids = rows.map { |r| r['key'][3] }.compact.uniq
+
+    bad = []
+    good = []
+    ids.each do |id|
+      doc = begin
+        db.get(id)
+      rescue StandardError
+        next
+      end
+      embedded_rows(doc['pails']).each do |pail|
+        number = pail['pail_number'].to_s
+        if number =~ /\A\d+\z/ && number.to_i >= bad_pail_threshold
+          bad << { doc_id: id, code: doc['code'], pail: pail }
+        elsif number =~ /\A\d+\z/
+          good << number.to_i
+        end
+      end
+    end
+
+    # Stable order: by date, then current number.
+    bad.sort_by! { |b| [b[:pail]['pail_date'].to_s, b[:pail]['pail_number'].to_i] }
+    [bad, good]
+  end
+
+  def pail_summary(pail)
+    finds = embedded_rows(pail['finds']).size
+    readings = embedded_rows(pail['readings']).size
+    "date=#{pail['pail_date'] || '—'}  finds=#{finds}  readings=#{readings}  " \
+      "total=#{pail['total_count'].presence || '—'}  baskets=#{pail['baskets'].presence || '—'}"
+  end
+
+  def empty_pail?(pail)
+    embedded_rows(pail['finds']).empty? && embedded_rows(pail['readings']).empty?
+  end
+
+  desc 'Report pails numbered >= 900 in a square, with a suggested fix (read-only). e.g. pails:audit[baluademo,25,61]'
+  task :audit, %i[project area square] => :environment do |_t, args|
+    project = args[:project] || abort('Usage: pails:audit[project,area,square]')
+    area = args[:area] || abort('Usage: pails:audit[project,area,square]')
+    square = args[:square] || abort('Usage: pails:audit[project,area,square]')
+
+    CouchDB.with_project(project) do
+      db = CouchDB.main_db
+      bad, good = scan_square(db, area, square)
+
+      puts "Square #{area}.#{square} — #{bad.size} bad pail(s) (>= #{bad_pail_threshold}); " \
+           "highest good pail number = #{good.max || 0}"
+      if bad.empty?
+        puts 'Nothing to do.'
+        next
+      end
+
+      next_num = (good.max || 0) + 1
+      bad.each do |entry|
+        pail = entry[:pail]
+        loc = "#{area}.#{square}.#{entry[:code]}"
+        if empty_pail?(pail)
+          suggestion = 'DELETE (empty)'
+        else
+          suggestion = "RENUMBER #{pail['pail_number']} -> #{next_num} (has data)"
+          next_num += 1
+        end
+        puts "  locus #{loc}  pail #{pail['pail_number'].to_s.ljust(6)}  #{pail_summary(pail)}"
+        puts "       => #{suggestion}"
+      end
+      puts "\nRun pails:fix[...] (APPLY=1 to write) to apply these suggestions."
+    end
+  end
+
+  desc 'Apply the bad-pail fix (DELETE empties, RENUMBER the rest). DRY by default; APPLY=1 to save.'
+  task :fix, %i[project area square] => :environment do |_t, args|
+    project = args[:project] || abort('Usage: pails:fix[project,area,square]')
+    area = args[:area] || abort('Usage: pails:fix[project,area,square]')
+    square = args[:square] || abort('Usage: pails:fix[project,area,square]')
+    apply = ENV['APPLY'].present?
+
+    CouchDB.with_project(project) do
+      db = CouchDB.main_db
+      bad, good = scan_square(db, area, square)
+
+      if bad.empty?
+        puts "Square #{area}.#{square}: no bad pails. Nothing to do."
+        next
+      end
+
+      # Plan renumber targets up front so they're stable across docs.
+      next_num = (good.max || 0) + 1
+      plan = bad.map do |entry|
+        if empty_pail?(entry[:pail])
+          entry.merge(action: :delete)
+        else
+          target = next_num
+          next_num += 1
+          entry.merge(action: :renumber, target: target)
+        end
+      end
+
+      # Group by host doc so each doc is rewritten and saved once.
+      deleted = 0
+      renumbered = 0
+      plan.group_by { |e| e[:doc_id] }.each do |doc_id, entries|
+        doc = db.get(doc_id)
+        pails = embedded_rows(doc['pails'])
+        delete_numbers = entries.select { |e| e[:action] == :delete }.map { |e| e[:pail]['pail_number'].to_s }
+        renumbers = entries.select { |e| e[:action] == :renumber }
+                           .to_h { |e| [e[:pail]['pail_number'].to_s, e[:target]] }
+
+        kept = pails.reject { |p| delete_numbers.include?(p['pail_number'].to_s) }
+        kept.each do |p|
+          newn = renumbers[p['pail_number'].to_s]
+          p['pail_number'] = newn.to_s if newn
+        end
+
+        deleted += delete_numbers.size
+        renumbered += renumbers.size
+        # Rewrite as a clean array (also heals any legacy Hash-shaped pails).
+        doc['pails'] = kept
+        db.save_doc(doc) if apply
+        puts "  #{area}.#{square}.#{doc['code']}: deleted #{delete_numbers.size}, renumbered #{renumbers.size}"
+      end
+
+      puts "\n#{apply ? 'APPLIED' : 'DRY RUN'} — deleted #{deleted}, renumbered #{renumbered} bad pail(s) in #{area}.#{square}." \
+           "#{apply ? '' : ' Set APPLY=1 to write.'}"
+    end
+  end
+end


### PR DESCRIPTION
Tools to sort out "bad" pail numbers (>= 900) — placeholders/junk nested in loci docs — scoped to one project + area + square.

## `pails:audit[project,area,square]` (read-only)
Lists every pail numbered ≥ 900 with its content (finds / readings / total / baskets) and a **suggested action**:
- **DELETE** if the pail has no finds and no readings (pure placeholder)
- **RENUMBER** to the next free number in the square (highest good number + 1, incrementing) if it holds data

```
RAILS_ENV=production bin/rails 'pails:audit[baluademo,25,61]'
```

## `pails:fix[project,area,square]` (dry-run by default)
Applies the audited policy. **DRY RUN unless `APPLY=1`.** Rewrites each affected doc's `pails` as a clean array (also heals any legacy Hash-shaped pails) and saves once per doc.

```
RAILS_ENV=production bin/rails 'pails:fix[baluademo,25,61]'          # preview
RAILS_ENV=production APPLY=1 bin/rails 'pails:fix[baluademo,25,61]'  # write
```

Both tasks tolerate legacy Hash-shaped embedded collections. Workflow: run `audit`, review the per-pail suggestions, then `fix` (dry, then APPLY=1).

`rubocop` clean; suggestion logic validated against the 25.61.005 fixture (pail 919 → DELETE).

🤖 Generated with [Claude Code](https://claude.com/claude-code)