### PR TITLE
Harden pails:audit/fix: basket-aware emptiness + index-based apply

### DIFF
--- a/lib/tasks/pails.rake
+++ b/lib/tasks/pails.rake
@@ -41,10 +41,13 @@ namespace :pails do
       rescue StandardError
         next
       end
-      embedded_rows(doc['pails']).each do |pail|
+      # Track each bad pail by its INDEX within the doc's pails: a single doc can
+      # hold two pails with the SAME bad number (e.g. two 999s), so we must act
+      # by position, not by number, or a delete/renumber would hit both.
+      embedded_rows(doc['pails']).each_with_index do |pail, index|
         number = pail['pail_number'].to_s
         if number =~ /\A\d+\z/ && number.to_i >= bad_pail_threshold
-          bad << { doc_id: id, code: doc['code'], pail: pail }
+          bad << { doc_id: id, code: doc['code'], index: index, pail: pail }
         elsif number =~ /\A\d+\z/
           good << number.to_i
         end
@@ -63,8 +66,17 @@ namespace :pails do
       "total=#{pail['total_count'].presence || '—'}  baskets=#{pail['baskets'].presence || '—'}"
   end
 
+  # A pail is only truly empty (safe to delete) when it carries no excavation
+  # data at all: no finds, no readings, AND no pottery counts/comments. A pail
+  # with baskets/total/diagnostic counts is a real collection even with no finds
+  # or readings entered yet, so it is renumbered rather than deleted.
   def empty_pail?(pail)
-    embedded_rows(pail['finds']).empty? && embedded_rows(pail['readings']).empty?
+    embedded_rows(pail['finds']).empty? &&
+      embedded_rows(pail['readings']).empty? &&
+      pail['baskets'].to_s.strip.empty? &&
+      pail['total_count'].to_s.strip.empty? &&
+      pail['diagnostic_count'].to_s.strip.empty? &&
+      pail['pottery_comments'].to_s.strip.empty?
   end
 
   desc 'Report pails numbered >= 900 in a square, with a suggested fix (read-only). e.g. pails:audit[baluademo,25,61]'
@@ -129,28 +141,32 @@ namespace :pails do
         end
       end
 
-      # Group by host doc so each doc is rewritten and saved once.
+      # Group by host doc so each doc is rewritten and saved once. Act by index
+      # (not by number) so two same-numbered bad pails in one doc are handled
+      # independently.
       deleted = 0
       renumbered = 0
       plan.group_by { |e| e[:doc_id] }.each do |doc_id, entries|
         doc = db.get(doc_id)
         pails = embedded_rows(doc['pails'])
-        delete_numbers = entries.select { |e| e[:action] == :delete }.map { |e| e[:pail]['pail_number'].to_s }
-        renumbers = entries.select { |e| e[:action] == :renumber }
-                           .to_h { |e| [e[:pail]['pail_number'].to_s, e[:target]] }
+        delete_idx = entries.select { |e| e[:action] == :delete }.map { |e| e[:index] }
+        renumber_idx = entries.select { |e| e[:action] == :renumber }
+                              .to_h { |e| [e[:index], e[:target]] }
 
-        kept = pails.reject { |p| delete_numbers.include?(p['pail_number'].to_s) }
-        kept.each do |p|
-          newn = renumbers[p['pail_number'].to_s]
-          p['pail_number'] = newn.to_s if newn
+        kept = []
+        pails.each_with_index do |pail, index|
+          next if delete_idx.include?(index)
+
+          pail['pail_number'] = renumber_idx[index].to_s if renumber_idx[index]
+          kept << pail
         end
 
-        deleted += delete_numbers.size
-        renumbered += renumbers.size
+        deleted += delete_idx.size
+        renumbered += renumber_idx.size
         # Rewrite as a clean array (also heals any legacy Hash-shaped pails).
         doc['pails'] = kept
         db.save_doc(doc) if apply
-        puts "  #{area}.#{square}.#{doc['code']}: deleted #{delete_numbers.size}, renumbered #{renumbers.size}"
+        puts "  #{area}.#{square}.#{doc['code']}: deleted #{delete_idx.size}, renumbered #{renumber_idx.size}"
       end
 
       puts "\n#{apply ? 'APPLIED' : 'DRY RUN'} — deleted #{deleted}, renumbered #{renumbered} bad pail(s) in #{area}.#{square}." \


### PR DESCRIPTION
Follow-up to #72 after running the audit on square 25.61, which surfaced two issues:

1. **A basket-only pail was wrongly marked for deletion.** Pail 919 has `baskets=52` but no finds/readings — it's a real pottery collection. "Empty" now also checks `baskets` / `total_count` / `diagnostic_count` / `pottery_comments`, so such pails are **renumbered**, not deleted.
2. **Same-numbered pails in one doc.** Locus 25.61.019 has **two pails numbered 999** (one empty, one with a find). The fix keyed delete/renumber by pail *number*, so it would have deleted both. It now tracks and applies decisions by pail **index** within the doc, handling each independently.

Verified against the real 25.61 plan:
```
016 99999 -> 164   018 99999 -> 165   005 919 -> 166   019 999(empty) DELETE   019 999(find) -> 167
```

`rubocop` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)