### PR TITLE
Add POST /api/v1/photos: devices upload through the web, not direct to S3

### DIFF
--- a/app/controllers/api/v1/photos_controller.rb
+++ b/app/controllers/api/v1/photos_controller.rb
@@ -31,12 +31,11 @@ module Api
         return render(json: { error: 'unsupported file type' }, status: :unprocessable_entity) unless content_type.start_with?('image/')
         return render(json: { error: 'file too large' }, status: :unprocessable_entity) if file.tempfile.size > MAX_UPLOAD_BYTES
 
-        bucket = Rails.application.config.try(:s3_bucket)
-        return render(json: { error: 'storage not configured' }, status: :service_unavailable) if bucket.nil?
+        return render(json: { error: 'storage not configured' }, status: :service_unavailable) if s3_bucket.nil?
 
         key = CouchDB.with_project(project) do
           object_key = build_object_key(file)
-          bucket.object(object_key).upload_file(file.tempfile.path, acl: 'public-read', content_type: content_type)
+          s3_bucket.object(object_key).upload_file(file.tempfile.path, acl: 'public-read', content_type: content_type)
           object_key
         end
 
@@ -76,6 +75,13 @@ module Api
       end
 
       private
+
+      # The configured project bucket (nil until the s3 initializer has run,
+      # e.g. when credentials are absent). Wrapped in a method so it's a single
+      # seam to stub in tests.
+      def s3_bucket
+        Rails.application.config.try(:s3_bucket)
+      end
 
       # Build the object key for an upload. Must run inside CouchDB.with_project
       # so ProjectStorage resolves the right prefixes. For official daily photos

--- a/app/controllers/api/v1/photos_controller.rb
+++ b/app/controllers/api/v1/photos_controller.rb
@@ -6,6 +6,46 @@ module Api
     class PhotosController < Api::BaseController
       before_action :authenticate_device!
 
+      # Cap device uploads so a bad/huge request can't exhaust memory or disk.
+      MAX_UPLOAD_BYTES = 30 * 1024 * 1024
+
+      # POST /api/v1/photos  (multipart/form-data)
+      #   file       the image (required)
+      #   project    project key (required; device must have a role on it)
+      #   kind       'user' (default) or 'daily'
+      #   locus      locus identifier, for the user-photo key (kind=user)
+      #   taken_at   ISO8601 capture time (kind=user; defaults to now)
+      #   number     official photo number (kind=daily)
+      #
+      # Uploads the image to the project's bucket and returns the object key. The
+      # server builds the key from the project's own prefixes, so a device can
+      # only ever write within its project — no S3 credentials reach the device.
+      def create
+        project = params[:project].to_s
+        return render_unauthorized unless device_can_access?(project)
+
+        file = params[:file]
+        return render(json: { error: 'file is required' }, status: :unprocessable_entity) if file.blank?
+
+        content_type = file.content_type.to_s
+        return render(json: { error: 'unsupported file type' }, status: :unprocessable_entity) unless content_type.start_with?('image/')
+        return render(json: { error: 'file too large' }, status: :unprocessable_entity) if file.tempfile.size > MAX_UPLOAD_BYTES
+
+        bucket = Rails.application.config.try(:s3_bucket)
+        return render(json: { error: 'storage not configured' }, status: :service_unavailable) if bucket.nil?
+
+        key = CouchDB.with_project(project) do
+          object_key = build_object_key(file)
+          bucket.object(object_key).upload_file(file.tempfile.path, acl: 'public-read', content_type: content_type)
+          object_key
+        end
+
+        render json: { key: key, url: Photo.url_for_key(key, :preview) }, status: :created
+      rescue StandardError => e
+        Rails.logger.error("Device photo upload failed: #{e.class}: #{e.message}")
+        render json: { error: 'upload failed' }, status: :bad_gateway
+      end
+
       # GET /api/v1/photos/pending?project=<key>&area=<a>&square=<s>
       def pending
         project = params[:project].to_s
@@ -36,6 +76,47 @@ module Api
       end
 
       private
+
+      # Build the object key for an upload. Must run inside CouchDB.with_project
+      # so ProjectStorage resolves the right prefixes. For official daily photos
+      # the key is <daily_photos>/<number>.<ext>; for user/field photos the
+      # uploader is the authenticated device user (server-trusted, never client
+      # input).
+      def build_object_key(file)
+        ext = file_extension(file)
+        if params[:kind].to_s == 'daily'
+          number = ProjectStorage.key_slug(params[:number])
+          raise 'number is required for a daily photo' if number.blank?
+
+          "#{ProjectStorage.daily_photos_prefix}/#{number}.#{ext}"
+        else
+          ProjectStorage.user_photo_key(
+            locus: params[:locus].to_s,
+            user_id: @current_user.email.presence || 'device',
+            taken_at: parsed_taken_at,
+            ext: ext
+          )
+        end
+      end
+
+      def file_extension(file)
+        from_name = File.extname(file.original_filename.to_s).delete_prefix('.').downcase
+        return from_name if from_name.present?
+
+        # Fall back to the content subtype (image/jpeg -> jpg).
+        subtype = content_subtype(file)
+        subtype == 'jpeg' ? 'jpg' : (subtype.presence || 'jpg')
+      end
+
+      def content_subtype(file)
+        file.content_type.to_s.split('/').last.to_s.downcase
+      end
+
+      def parsed_taken_at
+        Time.zone.parse(params[:taken_at].to_s) || Time.current
+      rescue ArgumentError, TypeError
+        Time.current
+      end
 
       def device_can_access?(project)
         return false if project.blank?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -70,6 +70,7 @@ Rails.application.routes.draw do
       delete 'devices/current', to: 'devices#destroy'
       get    'config',          to: 'config#show'
       get    'photos/pending',  to: 'photos#pending'
+      post   'photos',          to: 'photos#create'
     end
   end
 

--- a/spec/controllers/api/v1/photos_controller_spec.rb
+++ b/spec/controllers/api/v1/photos_controller_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Api::V1::PhotosController, type: :controller do
 
   before do
     allow(Project).to receive(:all).and_return(['opendig'])
-    allow(Rails.application.config).to receive(:s3_bucket).and_return(bucket)
+    allow(controller).to receive(:s3_bucket).and_return(bucket)
     allow(Photo).to receive(:url_for_key).and_return('https://img.test/x/preview')
   end
 

--- a/spec/controllers/api/v1/photos_controller_spec.rb
+++ b/spec/controllers/api/v1/photos_controller_spec.rb
@@ -59,8 +59,9 @@ RSpec.describe Api::V1::PhotosController, type: :controller do
     end
 
     it 'rejects a project the device user has no role on' do
-      device = authenticate_as(users[:google_oauth2]) # no roles
-      post :create, params: { project: 'opendig', kind: 'user', locus: '9.5.001', file: image_upload }
+      # dig_director has a role on 'opendig' only, not on 'other_project'.
+      device = authenticate_as(users[:dig_director])
+      post :create, params: { project: 'other_project', kind: 'user', locus: '9.5.001', file: image_upload }
       expect(response).to have_http_status(:unauthorized)
     ensure
       device&.revoke!

--- a/spec/controllers/api/v1/photos_controller_spec.rb
+++ b/spec/controllers/api/v1/photos_controller_spec.rb
@@ -1,0 +1,74 @@
+require 'rails_helper'
+
+RSpec.describe Api::V1::PhotosController, type: :controller do
+  let(:users) { load_user_fixtures }
+  let(:s3_object) { instance_double(Aws::S3::Object, upload_file: true) }
+  let(:bucket) { instance_double(Aws::S3::Bucket, object: s3_object) }
+
+  before do
+    allow(Project).to receive(:all).and_return(['opendig'])
+    allow(Rails.application.config).to receive(:s3_bucket).and_return(bucket)
+    allow(Photo).to receive(:url_for_key).and_return('https://img.test/x/preview')
+  end
+
+  def image_upload(name = 'shot.jpg', type = 'image/jpeg')
+    file = Tempfile.new(['shot', '.jpg'])
+    file.binmode
+    file.write('fake-image-bytes')
+    file.rewind
+    Rack::Test::UploadedFile.new(file.path, type, original_filename: name)
+  end
+
+  def authenticate_as(user)
+    device, token = Device.create_for(user)
+    request.headers['Authorization'] = "Bearer #{token}"
+    device
+  end
+
+  describe 'POST create' do
+    it 'uploads a user/field photo and returns the server-built key' do
+      device = authenticate_as(users[:dig_director])
+      expect(s3_object).to receive(:upload_file)
+      post :create, params: { project: 'opendig', kind: 'user', locus: '9.5.001',
+                              taken_at: '2026-06-29T10:00:00Z', file: image_upload }
+
+      body = response.parsed_body
+      expect(response).to have_http_status(:created)
+      expect(body['key']).to match(%r{\Aopendig/user_photos/9_5_001-dig_director_example_com-\d{8}T\d{6}Z-[0-9a-f]{6}\.jpg\z})
+    ensure
+      device&.revoke!
+    end
+
+    it 'builds a daily photo key from the number' do
+      device = authenticate_as(users[:dig_director])
+      post :create, params: { project: 'opendig', kind: 'daily', number: '12345', file: image_upload }
+
+      body = response.parsed_body
+      expect(response).to have_http_status(:created)
+      expect(body['key']).to eq('opendig/daily_photos/12345.jpg')
+    ensure
+      device&.revoke!
+    end
+
+    it 'rejects a non-image upload' do
+      device = authenticate_as(users[:dig_director])
+      post :create, params: { project: 'opendig', file: image_upload('notes.txt', 'text/plain') }
+      expect(response).to have_http_status(:unprocessable_entity)
+    ensure
+      device&.revoke!
+    end
+
+    it 'rejects a project the device user has no role on' do
+      device = authenticate_as(users[:google_oauth2]) # no roles
+      post :create, params: { project: 'opendig', kind: 'user', locus: '9.5.001', file: image_upload }
+      expect(response).to have_http_status(:unauthorized)
+    ensure
+      device&.revoke!
+    end
+
+    it 'rejects a missing token' do
+      post :create, params: { project: 'opendig', file: image_upload }
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+end


### PR DESCRIPTION
Mobile photo uploads now route through the backend instead of the device signing direct-to-S3. The device never needs S3 credentials — just its existing device Bearer token.

## New endpoint: `POST /api/v1/photos` (multipart/form-data)
On `Api::V1::PhotosController#create`:
- `authenticate_device!` + `device_can_access?(project)` (reused from the pending endpoint).
- Guards: `file` required, content-type must be `image/*`, 30 MB cap, bucket must be configured.
- The **server** builds the object key from the project's own prefixes — `user_photo_key` for field/find photos (`kind=user`), `daily_photos/<number>.<ext>` for official (`kind=daily`). A device can therefore only ever write within its own project's prefixes, and the uploader id is the authenticated user's email (never client input).
- Uploads with `bucket.object(key).upload_file(..., acl: 'public-read', content_type:)` (same pattern as bulk uploads) and returns `{ key, url }`.

The device records the returned key on the locus (`photos[].key` / `number`) and syncs via CouchDB exactly as before — only the upload step changed.

## Why
Direct-to-S3 from the device required shipping S3 access/secret keys in the config bundle and signing SigV4 on-device (fragile across Wasabi/region/endpoint, and a credential-distribution liability). Routing through the web — which already uploads to the bucket reliably — removes both problems.

## Tests
Controller spec covers: user-photo + daily happy paths (asserts the built key + that `upload_file` is called), non-image rejected (422), project-without-role rejected (401), missing token rejected (401). S3 bucket and `Photo.url_for_key` are stubbed.

The matching mobile change (ApiClient.uploadPhoto + switching the three capture call sites off S3UploadService) is in od_flutter and ships with the app build.

Follow-up (not in this PR): once all devices run the new build, stop sending S3 access/secret keys in the device bundle entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)