### PR TITLE
Locus page: designate field-note photos + open photos in a modal

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -8,6 +8,24 @@ module ApplicationHelper
     Array(rows).select { |row| row.is_a?(Hash) }
   end
 
+  # A field-note ("user") photo vs an official daily photo. Field notes are
+  # tagged with a type by the device ('user_photo'; legacy 'field_note').
+  def field_note_photo?(photo)
+    %w[user_photo field_note].include?(photo['type'].to_s)
+  end
+
+  # Every field-note photo for a locus: the dedicated user_photos[] array plus
+  # any photos[] entries the device tagged as field notes (the mobile app writes
+  # field notes into photos[]).
+  def field_note_photos(locus)
+    hash_rows(locus['user_photos']) + hash_rows(locus['photos']).select { |p| field_note_photo?(p) }
+  end
+
+  # Official photos only: photos[] entries that aren't field notes.
+  def official_photos(locus)
+    hash_rows(locus['photos']).reject { |p| field_note_photo?(p) }
+  end
+
   # Always begin the OAuth handshake on the apex domain (opendig.org), so the
   # provider (Google) needs only one registered redirect URI instead of one per
   # subdomain. The `origin` carries the user back to the subdomain they started

--- a/app/views/loci/_photo_lightbox.html.erb
+++ b/app/views/loci/_photo_lightbox.html.erb
@@ -1,0 +1,18 @@
+<%# Shared full-size photo popup for the locus page. The enclosing .locus-show
+    sets x-data; each thumbnail sets open/img/caption/meta on click. Click the
+    backdrop, the ✕, or Esc to close. %>
+<div x-show="open" x-cloak
+     @click="open=false" @keydown.escape.window="open=false"
+     class="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4">
+  <div @click.stop class="bg-white rounded-xl max-w-4xl w-full max-h-[90vh] overflow-auto shadow-xl">
+    <div class="flex justify-end p-2">
+      <button type="button" @click="open=false" aria-label="Close"
+              class="text-[#6a5d4c] hover:text-[#2a231b] text-3xl leading-none px-2">&times;</button>
+    </div>
+    <img :src="img" alt="" class="w-full max-h-[70vh] object-contain bg-black">
+    <div class="p-4 border-t border-[#e7dcc4]">
+      <div class="font-medium text-[#2a231b]" x-text="caption"></div>
+      <div class="text-sm text-[#6a5d4c] mt-1" x-show="meta" x-text="meta"></div>
+    </div>
+  </div>
+</div>

--- a/app/views/loci/_photos.html.erb
+++ b/app/views/loci/_photos.html.erb
@@ -11,7 +11,7 @@
         </tr>
       </thead>
       <tbody>
-        <% hash_rows(@locus['photos']).each do |photo| %>
+        <% official_photos(@locus).each do |photo| %>
           <%
             # Convention-named/bulk photos reference an S3 key; legacy daily
             # photos reference a number.
@@ -19,15 +19,19 @@
             # `preview` (600px, fit) instead of `thumb` (100px): the grid renders
             # these at ~128px and 2x on hi-DPI, so a 100px thumb looks blurry.
             thumb  = photo["key"].present? ? Photo.url_for_key(photo["key"], :preview) : Photo.photo_url(photo["number"], :preview)
+            label  = photo["number"].presence || photo["filename"]
           %>
           <tr class="hover:bg-gray-200">
             <td class="px-4 py-2 text-left"><%= read_date photo["date"] %></td>
-            <td class="px-4 py-2 text-left"><%= photo["number"].presence || photo["filename"] %></td>
+            <td class="px-4 py-2 text-left"><%= label %></td>
             <td class="px-4 py-2 text-left"><%= photo["subject"] %></td>
             <td class="px-4 py-2 text-center">
-              <a class="locus-photo-link flex justify-center" href="<%= medium %>" data-lightbox="locus-photos">
-                <img class="locus-photo w-32 h-32 object-cover rounded" src="<%= thumb %>" alt="" />
-              </a>
+              <img class="locus-photo w-32 h-32 object-cover rounded mx-auto cursor-pointer hover:opacity-90 transition"
+                   src="<%= thumb %>" alt="" loading="lazy"
+                   data-full="<%= medium %>"
+                   data-caption="<%= label %>"
+                   data-meta="<%= [read_date(photo['date']), photo['subject']].map(&:presence).compact.join(' · ') %>"
+                   @click="open=true; img=$el.dataset.full; caption=$el.dataset.caption; meta=$el.dataset.meta" />
             </td>
           </tr>
         <% end %>

--- a/app/views/loci/_user_photos.html.erb
+++ b/app/views/loci/_user_photos.html.erb
@@ -16,15 +16,29 @@
         </tr>
       </thead>
       <tbody>
-        <% hash_rows(@locus['user_photos']).each do |photo| %>
+        <% field_note_photos(@locus).each do |photo| %>
+          <%
+            # Field notes come from two shapes: the dedicated user_photos[] array
+            # (taken_at + user_name) and photos[] entries the device tagged as
+            # field notes (date, usually no uploader).
+            date     = read_date(photo["taken_at"].presence || photo["date"])
+            uploader = photo["user_name"].presence || photo["user"].presence
+          %>
           <tr class="hover:bg-amber-100">
-            <td class="px-4 py-2 text-left"><%= read_date(photo["taken_at"]) %></td>
-            <td class="px-4 py-2 text-left"><%= photo["user_name"].presence || photo["user"] %></td>
+            <td class="px-4 py-2 text-left"><%= date %></td>
+            <td class="px-4 py-2 text-left"><%= uploader || '—' %></td>
             <td class="px-4 py-2 text-left"><%= photo["subject"] %></td>
             <td class="px-4 py-2 text-center">
-              <a class="locus-photo-link flex justify-center" href="<%= Photo.url_for_key(photo["key"], :medium) %>" data-lightbox="locus-field-photos">
-                <img class="locus-photo w-32 h-32 object-cover rounded" src="<%= Photo.url_for_key(photo["key"], :preview) %>" alt="" />
-              </a>
+              <% if photo["key"].present? %>
+                <img class="locus-photo w-32 h-32 object-cover rounded mx-auto cursor-pointer hover:opacity-90 transition"
+                     src="<%= Photo.url_for_key(photo["key"], :preview) %>" alt="" loading="lazy"
+                     data-full="<%= Photo.url_for_key(photo["key"], :medium) %>"
+                     data-caption="<%= [photo['subject'].presence, 'Field note'].compact.join(' · ') %>"
+                     data-meta="<%= [date, uploader].map(&:presence).compact.join(' · ') %>"
+                     @click="open=true; img=$el.dataset.full; caption=$el.dataset.caption; meta=$el.dataset.meta" />
+              <% else %>
+                <span class="text-amber-700 text-xs">No image</span>
+              <% end %>
             </td>
           </tr>
         <% end %>

--- a/app/views/loci/show.html.erb
+++ b/app/views/loci/show.html.erb
@@ -1,5 +1,5 @@
 <!-- Document ID: <%= @locus['_id'] %> -->
-<div class="locus-show container mx-auto max-w-4xl px-2 py-8">
+<div class="locus-show container mx-auto max-w-4xl px-2 py-8" x-data="{ open:false, img:'', caption:'', meta:'' }">
   <nav class="text-sm text-[#6a5d4c] mb-2">
     <%= link_to "Home", root_path, class: "hover:text-[#b1542b]" %>
     <span class="mx-1" aria-hidden="true">/</span>
@@ -31,11 +31,14 @@
   <%= render 'stratigraphy' if @locus["stratigraphies"] %>
   <%= render 'pottery' if @locus["pottery"] %>
   <%= render 'pails' if @locus["pails"] %>
-  <%= render 'photos' if @locus["photos"] %>
-  <%= render 'user_photos' if @locus["user_photos"].present? %>
+  <%= render 'photos' if official_photos(@locus).any? %>
+  <%= render 'user_photos' if field_note_photos(@locus).any? %>
+
+  <%= render 'photo_lightbox' %>
 </div>
 
 <style>
+  [x-cloak] { display: none !important; }
   /* Locus display theme (parchment / terracotta). Scoped to .locus-show. */
   .locus-show .ls-card {
     margin-bottom: 1.5rem; border: 1px solid #ddcfb4; background: #fbf6ec;


### PR DESCRIPTION
Two fixes on the locus show page.

## Field notes are now clearly designated
The mobile app writes field notes into `photos[]` tagged `type: 'user_photo'`, but the web rendered every `photos[]` row identically in the official **Photos** table — so field notes showed up there, unmarked. (The dedicated amber **Field Photos** section read a different array, `user_photos[]`, that the device never writes.)

New helpers — `field_note_photo?`, `field_note_photos`, `official_photos` — route every field note (from `photos[]` *and* the legacy `user_photos[]`) into the amber "Field Photos" section, and keep only official photos in "Photos". Field notes from `photos[]` and `user_photos[]` have slightly different shapes (`date`/`taken_at`, uploader present or not), which the partial now normalizes.

## Click opens a popup, not a new tab
The thumbnails were `<a href=… data-lightbox=…>` but no lightbox library is loaded, so clicking just opened the image. Replaced with a shared Alpine modal (`_photo_lightbox`) — the same pattern already used on the `/photos` page (Alpine is loaded in the layout). Thumbnails set the modal's state on click; backdrop / ✕ / Esc close it. Works for both official and field-note photos.

ERB compiles; `rubocop` clean; no leftover `data-lightbox` anchors remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)