### PR TITLE
Registrar: artifact photo gallery with a settable cover (web)

### DIFF
--- a/app/controllers/registrar_controller.rb
+++ b/app/controllers/registrar_controller.rb
@@ -1,8 +1,8 @@
 class RegistrarController < ApplicationController
   # Supervisors may read the registrar; only registrar/dig_director/superuser may write.
   before_action :require_registrar_read
-  before_action :require_registrar_write, only: %i[new create edit update destroy discard restore]
-  before_action :set_item, only: %i[show edit update discard restore]
+  before_action :require_registrar_write, only: %i[new create edit update destroy discard restore set_cover]
+  before_action :set_item, only: %i[show edit update discard restore set_cover]
 
   def index
     # Seasons present in the data, plus the current one so a new season is
@@ -84,6 +84,20 @@ class RegistrarController < ApplicationController
       redirect_to registrar_path(**find_path_params), notice: 'Find restored to Incoming.'
     else
       redirect_to registrar_path(**find_path_params), alert: 'Something went wrong restoring the find.'
+    end
+  end
+
+  # Choose which of a find's photos is the cover (main) image. The cover_key
+  # must be one of the find's actual photos, so a bad value can't be stored.
+  def set_cover
+    key = params[:cover_key].to_s
+    return redirect_to registrar_path(**find_path_params), alert: 'That photo could not be found.' unless helpers.find_photos(@find).any? { |p| p['key'] == key }
+
+    @find['cover_key'] = key
+    if @doc.save
+      redirect_to registrar_path(**find_path_params), notice: 'Cover photo updated.'
+    else
+      redirect_to registrar_path(**find_path_params), alert: 'Could not update the cover photo.'
     end
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -26,6 +26,34 @@ module ApplicationHelper
     hash_rows(locus['photos']).reject { |p| field_note_photo?(p) }
   end
 
+  # Assemble an artifact (find)'s photos for display, de-duped by key:
+  #   - official images discovered by the registration-number bucket prefix
+  #     (the registrar's catalogue uploads), kept as-is, type 'official';
+  #   - the find's own photos[] entries (official or note), which take
+  #     precedence over a prefix-derived entry with the same key so their
+  #     type/metadata wins;
+  #   - the legacy single photo_key (a field note from older mobile builds).
+  def find_photos(find)
+    by_key = {}
+    reg = find['registration_number']
+    Find.get_image_keys(reg).each { |k| by_key[k] = { 'key' => k, 'type' => 'official' } } if Find.can_have_image?(reg)
+    hash_rows(find['photos']).each do |p|
+      by_key[p['key']] = p if p['key'].present?
+    end
+    legacy = find['photo_key']
+    by_key[legacy] ||= { 'key' => legacy, 'type' => 'user_photo' } if legacy.present?
+    by_key.values
+  end
+
+  # The key of the find's cover (main) photo: the stored cover_key if it still
+  # points at a present photo, else the first official, else the first photo.
+  def find_cover_key(find, photos = find_photos(find))
+    explicit = find['cover_key']
+    return explicit if explicit.present? && photos.any? { |p| p['key'] == explicit }
+
+    (photos.find { |p| !field_note_photo?(p) } || photos.first)&.dig('key')
+  end
+
   # Always begin the OAuth handshake on the apex domain (opendig.org), so the
   # provider (Google) needs only one registered redirect URI instead of one per
   # subdomain. The `origin` carries the user back to the subdomain they started

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -36,7 +36,9 @@ module ApplicationHelper
   def find_photos(find)
     by_key = {}
     reg = find['registration_number']
-    Find.get_image_keys(reg).each { |k| by_key[k] = { 'key' => k, 'type' => 'official' } } if Find.can_have_image?(reg)
+    if reg.present? && Find.can_have_image?(reg)
+      Find.get_image_keys(reg).each { |k| by_key[k] = { 'key' => k, 'type' => 'official' } }
+    end
     hash_rows(find['photos']).each do |p|
       by_key[p['key']] = p if p['key'].present?
     end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -36,9 +36,8 @@ module ApplicationHelper
   def find_photos(find)
     by_key = {}
     reg = find['registration_number']
-    if reg.present? && Find.can_have_image?(reg)
-      Find.get_image_keys(reg).each { |k| by_key[k] = { 'key' => k, 'type' => 'official' } }
-    end
+    official_keys = reg.present? && Find.can_have_image?(reg) ? Find.get_image_keys(reg) : []
+    official_keys.each { |k| by_key[k] = { 'key' => k, 'type' => 'official' } }
     hash_rows(find['photos']).each do |p|
       by_key[p['key']] = p if p['key'].present?
     end

--- a/app/views/registrar/show.html.erb
+++ b/app/views/registrar/show.html.erb
@@ -1,4 +1,5 @@
-<div class="container mx-auto max-w-5xl px-2 py-8">
+<style>[x-cloak]{display:none !important;}</style>
+<div class="container mx-auto max-w-5xl px-2 py-8" x-data="{ open:false, img:'', caption:'', meta:'' }">
   <nav class="text-sm text-[#6a5d4c] mb-2">
     <%= link_to 'Registrar', registrar_index_path, class: "hover:text-[#b1542b]" %>
     <span class="mx-1" aria-hidden="true">/</span>
@@ -79,19 +80,51 @@
     </div>
 
     <div class="rounded-xl border border-[#ddcfb4] bg-[#fbf6ec] p-4">
-      <h2 class="font-serif text-lg text-[#2a231b] mb-3">Images</h2>
-      <% image_keys = Find.can_have_image?(@find['registration_number']) ? Find.get_image_keys(@find['registration_number']) : [] %>
-      <% if image_keys.any? %>
-        <div class="space-y-3">
-          <% image_keys.each do |key| %>
-            <%= link_to Find.url(key, :original), target: "_blank", rel: "noopener", class: "block" do %>
-              <%= image_tag Find.url(key, :medium), class: "w-full rounded-lg border border-[#e7dcc4]", loading: "lazy", alt: "Find image" %>
+      <h2 class="font-serif text-lg text-[#2a231b] mb-3">Photos</h2>
+      <% photos = find_photos(@find) %>
+      <% cover_key = find_cover_key(@find, photos) %>
+      <% if photos.any? %>
+        <% cover = photos.find { |p| p['key'] == cover_key } || photos.first %>
+        <%# Cover (main) photo — click to open full size in a popup. %>
+        <img src="<%= Photo.url_for_key(cover['key'], :medium) %>" alt="Find cover photo" loading="lazy"
+             class="w-full rounded-lg border border-[#e7dcc4] cursor-pointer hover:opacity-95 transition"
+             data-full="<%= Photo.url_for_key(cover['key'], :original) %>"
+             data-caption="<%= field_note_photo?(cover) ? 'Note' : 'Official' %>"
+             @click="open=true; img=$el.dataset.full; caption=$el.dataset.caption; meta=''" />
+        <%# Gallery — every photo; the cover is highlighted, notes are badged. %>
+        <% if photos.size > 1 %>
+          <div class="grid grid-cols-3 gap-2 mt-3">
+            <% photos.each do |p| %>
+              <% note = field_note_photo?(p) %>
+              <% is_cover = p['key'] == cover_key %>
+              <div>
+                <div class="relative">
+                  <img src="<%= Photo.url_for_key(p['key'], :preview) %>" alt="" loading="lazy"
+                       class="w-full h-20 object-cover rounded cursor-pointer hover:opacity-90 ring-1 <%= is_cover ? 'ring-2 ring-[#b1542b]' : 'ring-[#e7dcc4]' %>"
+                       data-full="<%= Photo.url_for_key(p['key'], :original) %>"
+                       data-caption="<%= note ? 'Note' : 'Official' %>"
+                       @click="open=true; img=$el.dataset.full; caption=$el.dataset.caption; meta=''" />
+                  <% if note %>
+                    <span class="absolute top-1 left-1 rounded border border-amber-300 bg-amber-100 px-1 text-[10px] font-medium uppercase text-amber-800">Note</span>
+                  <% end %>
+                </div>
+                <div class="mt-1 text-center">
+                  <% if is_cover %>
+                    <span class="text-[10px] font-semibold uppercase text-[#b1542b]">Cover</span>
+                  <% elsif current_user&.can_edit_registrar? %>
+                    <%= button_to "Set as cover",
+                          set_cover_registrar_path(id: @item_id, pail_id: @pail_id, item_number: @item_number, item_locus_code: @item_locus_code, cover_key: p['key']),
+                          method: :patch,
+                          class: "border-0 bg-transparent p-0 text-[11px] text-[#b1542b] hover:underline cursor-pointer" %>
+                  <% end %>
+                </div>
+              </div>
             <% end %>
-          <% end %>
-        </div>
+          </div>
+        <% end %>
       <% else %>
         <div class="flex h-40 items-center justify-center rounded-lg border border-dashed border-[#ddcfb4] text-sm text-[#9c8e78]">
-          No images
+          No photos
         </div>
       <% end %>
     </div>
@@ -108,4 +141,6 @@
       <% end %>
     </dl>
   </div>
+
+  <%= render 'loci/photo_lightbox' %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,6 +36,7 @@ Rails.application.routes.draw do
     member do
       patch :discard
       patch :restore
+      patch :set_cover
     end
   end
   resources :bulk_uploads, only: %i[new create]

--- a/spec/controllers/registrar_controller_spec.rb
+++ b/spec/controllers/registrar_controller_spec.rb
@@ -131,6 +131,46 @@ RSpec.describe RegistrarController, type: :controller do
     end
   end
 
+  describe 'PATCH set_cover' do
+    let(:item) do
+      { 'field_number' => '1',
+        'photos' => [{ 'key' => 'balua/finds/k1.jpg', 'type' => 'official' }] }
+    end
+    let(:doc) do
+      d = { 'pails' => [{ 'pail_number' => '1', 'finds' => [item] }] }
+      def d.save = true
+      d
+    end
+    let(:params) { { id: 'doc1', pail_id: '1', item_number: '1', item_locus_code: '1.1.001' } }
+
+    before do
+      allow(db).to receive(:get).with('doc1').and_return(doc)
+      # Skip the S3 prefix lookup; the find's own photos[] is enough here.
+      allow(Find).to receive(:can_have_image?).and_return(false)
+    end
+
+    it "sets the cover to one of the find's photos" do
+      session[:user_id] = users[:registrar].id
+      patch :set_cover, params: params.merge(cover_key: 'balua/finds/k1.jpg')
+      expect(item['cover_key']).to eq('balua/finds/k1.jpg')
+      expect(response).to redirect_to(registrar_path(**params))
+    end
+
+    it "rejects a key that isn't one of the find's photos" do
+      session[:user_id] = users[:registrar].id
+      patch :set_cover, params: params.merge(cover_key: 'balua/finds/evil.jpg')
+      expect(item).not_to have_key('cover_key')
+      expect(response).to redirect_to(registrar_path(**params))
+    end
+
+    it 'forbids a read-only area supervisor' do
+      session[:user_id] = users[:area_supervisor].id
+      patch :set_cover, params: params.merge(cover_key: 'balua/finds/k1.jpg')
+      expect(response).to redirect_to(controller.root_path)
+      expect(item).not_to have_key('cover_key')
+    end
+  end
+
   describe 'GET edit (write access)' do
     let(:params) { { id: 'doc1', pail_id: '1', item_number: '1', item_locus_code: '1.1.001' } }
 

--- a/spec/controllers/registrar_controller_spec.rb
+++ b/spec/controllers/registrar_controller_spec.rb
@@ -143,11 +143,9 @@ RSpec.describe RegistrarController, type: :controller do
     end
     let(:params) { { id: 'doc1', pail_id: '1', item_number: '1', item_locus_code: '1.1.001' } }
 
-    before do
-      allow(db).to receive(:get).with('doc1').and_return(doc)
-      # Skip the S3 prefix lookup; the find's own photos[] is enough here.
-      allow(Find).to receive(:can_have_image?).and_return(false)
-    end
+    # The find has no registration_number, so Find.can_have_image? short-circuits
+    # on the blank check (no bucket lookup) and find_photos uses photos[] only.
+    before { allow(db).to receive(:get).with('doc1').and_return(doc) }
 
     it "sets the cover to one of the find's photos" do
       session[:user_id] = users[:registrar].id


### PR DESCRIPTION
The registrar find (artifact) page now shows photos as a **cover (main) image + gallery**, with official-vs-note distinction, and clicking opens a **popup** instead of a new tab. (Web half; mobile multi-photo capture follows in an app build.)

Per the agreed design: official/note is per-photo, existing registrar catalogue images stay official (no migration), web ships first.

## What changed
- **`find_photos(find)`** assembles a find's photos de-duped by key, from three sources, layered:
  - registrar catalogue images discovered by the `finds/<registration_number>` bucket prefix → **official** (unchanged, no migration);
  - the find's own `photos[]` entries (`type: official` or `user_photo`), which win on duplicate keys so their type/metadata is preserved;
  - the legacy single `photo_key` from older mobile builds → treated as a **note**, so those photos finally show on the web.
- **`find_cover_key(find)`** → the stored `cover_key` if it still points at a present photo, else first official, else first photo.
- **Cover + gallery UI** on `registrar/show`: cover image up top; gallery below; notes get an amber **Note** badge; the cover is ringed + labelled **Cover**; clicking any image opens the shared Alpine lightbox (the same `loci/_photo_lightbox`). Registrar-write users get **Set as cover** per photo.
- **`PATCH /registrar/:id/set_cover`** validates the key is one of the find's photos (so an arbitrary value can't be stored), sets `cover_key` on the embedded find, and saves via the same `@doc.save` path as discard/restore.

## Tests
`set_cover`: sets cover to a valid photo, rejects a key not belonging to the find, forbidden for a read-only area supervisor. `rubocop` clean; ERB compiles; route verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)