### PR TITLE
Serve find images through imgproxy, never the full original

### DIFF
--- a/app/models/find.rb
+++ b/app/models/find.rb
@@ -42,16 +42,14 @@ class Find
 
   NO_IMAGE_PLACEHOLDER = 'https://via.placeholder.com/250x250.png?text=No+Image'.freeze
 
-  def self.get_presigned_urls(registration_number)
-    bucket = Rails.application.config.try(:s3_bucket)
-    return [NO_IMAGE_PLACEHOLDER] if bucket.nil? || !Find.can_have_image?(registration_number)
+  # Imgproxy URL for a find's representative (first) image at the given style, or
+  # the placeholder when it has none. Use wherever a single find image is shown
+  # (reports, lists) so a resized image is served — never the full original.
+  def self.image_url(registration_number, style = :medium)
+    return NO_IMAGE_PLACEHOLDER unless can_have_image?(registration_number)
 
-    Rails.cache.fetch("#{ProjectStorage.storage_project}/#{registration_number}_presigned_urls", expires_in: 5.minutes) do
-      get_image_keys(registration_number).map { |key| bucket.object(key).presigned_url(:get) }
-    end
-  rescue StandardError => e
-    Rails.logger.warn("Find.get_presigned_urls failed for #{registration_number}: #{e.class}: #{e.message}")
-    [NO_IMAGE_PLACEHOLDER]
+    key = get_image_keys(registration_number).first
+    key ? url(key, style) : NO_IMAGE_PLACEHOLDER
   end
 
   def self.url(key, style = :original)
@@ -68,6 +66,5 @@ class Find
     prefix = ProjectStorage.storage_project
     Rails.cache.delete("#{prefix}/#{registration_number}_images")
     Rails.cache.delete("#{prefix}/#{registration_number}_has_keys")
-    Rails.cache.delete("#{prefix}/#{registration_number}_presigned_urls")
   end
 end

--- a/app/views/registrar/show.html.erb
+++ b/app/views/registrar/show.html.erb
@@ -88,7 +88,7 @@
         <%# Cover (main) photo — click to open full size in a popup. %>
         <img src="<%= Photo.url_for_key(cover['key'], :medium) %>" alt="Find cover photo" loading="lazy"
              class="w-full rounded-lg border border-[#e7dcc4] cursor-pointer hover:opacity-95 transition"
-             data-full="<%= Photo.url_for_key(cover['key'], :original) %>"
+             data-full="<%= Photo.url_for_key(cover['key'], :medium) %>"
              data-caption="<%= field_note_photo?(cover) ? 'Note' : 'Official' %>"
              @click="open=true; img=$el.dataset.full; caption=$el.dataset.caption; meta=''" />
         <%# Gallery — every photo; the cover is highlighted, notes are badged. %>
@@ -101,7 +101,7 @@
                 <div class="relative">
                   <img src="<%= Photo.url_for_key(p['key'], :preview) %>" alt="" loading="lazy"
                        class="w-full h-20 object-cover rounded cursor-pointer hover:opacity-90 ring-1 <%= is_cover ? 'ring-2 ring-[#b1542b]' : 'ring-[#e7dcc4]' %>"
-                       data-full="<%= Photo.url_for_key(p['key'], :original) %>"
+                       data-full="<%= Photo.url_for_key(p['key'], :medium) %>"
                        data-caption="<%= note ? 'Note' : 'Official' %>"
                        @click="open=true; img=$el.dataset.full; caption=$el.dataset.caption; meta=''" />
                   <% if note %>

--- a/app/views/reports/pdf_photo.html.erb
+++ b/app/views/reports/pdf_photo.html.erb
@@ -20,7 +20,7 @@
       </td>
       <td class="report_image">
         <% if Find.can_have_image?(row.dig('registration_number')) %>
-          <%= image_tag(Find.get_presigned_url(row.dig('registration_number')), class: 'find-img') %>
+          <%= image_tag(Find.image_url(row.dig('registration_number'), :medium), class: 'find-img') %>
         <% end %>
       </td>
     </tr>

--- a/app/views/reports/show_photo.html.erb
+++ b/app/views/reports/show_photo.html.erb
@@ -16,7 +16,7 @@
       </div>
       <div class="col-3">
         <% if Find.can_have_image?(row.dig('registration_number')) %>
-          <%= image_tag(Find.get_presigned_url(row.dig('registration_number')), class: 'find-img-small') %>
+          <%= image_tag(Find.image_url(row.dig('registration_number'), :preview), class: 'find-img-small', loading: 'lazy') %>
         <% end %>
       </div>
     </div>


### PR DESCRIPTION
Artifact (find) images were being served at full size in places — specifically the **reports**, which rendered thumbnails with `Find.get_presigned_url(...)`: a method that **doesn't exist** (only the plural `get_presigned_urls` was defined, so this was a latent `NoMethodError`) and whose intent was a **presigned full original** straight from S3, bypassing imgproxy entirely. A report with many finds was pulling full-resolution originals into ~175px slots.

## Changes
- New `Find.image_url(registration_number, style = :medium)` — imgproxy URL for the find's representative (first) image at a sized style, or the placeholder. The single seam for "show one find image."
- `reports/show_photo` (HTML, `find-img-small` ~175px) → `Find.image_url(reg, :preview)`; `reports/pdf_photo` (print, `find-img` ~175px) → `:medium`. Both now resized, not originals. Added `loading: lazy` on the HTML report.
- Registrar artifact gallery lightbox: `data-full` now `:medium` instead of `:original`, so clicking a photo no longer downloads the full-resolution image (consistent with the loci photo popups). The cover (`:medium`) and gallery thumbs (`:preview`) were already imgproxy-resized.
- Removed the now-unused `get_presigned_urls` and its cache key.

Net: every displayed find/photo image goes through imgproxy at a sized style — no view serves an un-resized original as an `<img>` `src` anymore.

ERB compiles; `rubocop` clean; no specs referenced the removed method.

🤖 Generated with [Claude Code](https://claude.com/claude-code)