### PR TITLE
Per-project descriptions editor for dig directors

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -367,6 +367,7 @@ Rails/I18nLocaleTexts:
     - 'app/controllers/admin_controller.rb'
     - 'app/controllers/application_controller.rb'
     - 'app/controllers/areas_controller.rb'
+    - 'app/controllers/descriptions_controller.rb'
     - 'app/controllers/invitations_controller.rb'
     - 'app/controllers/loci_controller.rb'
     - 'app/controllers/pails_controller.rb'

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -44,7 +44,7 @@ class ApplicationController < ActionController::Base
   end
 
   def set_descriptions
-    @descriptions = Rails.application.config.descriptions
+    @descriptions = ProjectDescriptions.effective(current_project)
   end
 
   def set_edit_mode
@@ -202,6 +202,8 @@ class ApplicationController < ActionController::Base
 
   # User role management for the project.
   def require_manage_users = require_capability(:can_manage_roles?, "manage users")
+
+  def require_edit_descriptions = require_capability(:can_edit_descriptions?, "edit descriptions")
 
   def require_dig_data_edit(role_label, area:, square: nil)
     require_authentication

--- a/app/controllers/descriptions_controller.rb
+++ b/app/controllers/descriptions_controller.rb
@@ -1,0 +1,71 @@
+# Dig-director (and superuser) editor for the project's descriptions config.
+# Two modes:
+#   - lookups: friendly per-list editor (one value per line) for the lookup
+#     value lists (designation, material, …);
+#   - raw:     a validated JSON editor for the whole descriptions document.
+# Both persist a per-project override via ProjectDescriptions (the static
+# defaults stay as a fallback and can be re-inherited via Reset).
+class DescriptionsController < ApplicationController
+  before_action :require_edit_descriptions
+
+  REQUIRED_KEYS = %w[lookups description_types].freeze
+
+  def edit
+    @effective = ProjectDescriptions.effective(current_project)
+    @lookups = (@effective['lookups'] || {}).sort.to_h
+    @version = ProjectDescriptions.version(current_project)
+    @raw_json = JSON.pretty_generate(@effective)
+  end
+
+  def update
+    case params[:mode]
+    when 'raw'
+      update_raw
+    else
+      update_lookups
+    end
+  end
+
+  def destroy
+    ProjectDescriptions.reset(current_project)
+    redirect_to edit_descriptions_path, notice: 'Descriptions reset to the defaults.'
+  end
+
+  private
+
+  # Friendly lookup editor: params[:lookups] = { name => "val1\nval2\n…" }.
+  # Merges the edited lookups into the existing override so any raw-mode edits to
+  # other sections are preserved.
+  def update_lookups
+    edited = (params[:lookups] || {}).to_unsafe_h.transform_values do |text|
+      text.to_s.split("\n").map(&:strip).compact_blank
+    end
+    override = ProjectDescriptions.override(current_project).deep_dup
+    override['lookups'] = (override['lookups'] || {}).merge(edited)
+    ProjectDescriptions.save(current_project, override)
+    redirect_to edit_descriptions_path, notice: 'Lookup lists updated.'
+  end
+
+  # Advanced: replace the whole descriptions document from validated JSON.
+  def update_raw
+    parsed = JSON.parse(params[:raw_json].to_s)
+    unless parsed.is_a?(Hash) && REQUIRED_KEYS.all? { |k| parsed.key?(k) }
+      flash.now[:error] = "Invalid descriptions: must be a JSON object including #{REQUIRED_KEYS.join(', ')}."
+      return render_edit_with(parsed_raw: params[:raw_json])
+    end
+
+    ProjectDescriptions.save(current_project, parsed)
+    redirect_to edit_descriptions_path, notice: 'Descriptions updated from JSON.'
+  rescue JSON::ParserError => e
+    flash.now[:error] = "Invalid JSON: #{e.message}"
+    render_edit_with(parsed_raw: params[:raw_json])
+  end
+
+  def render_edit_with(parsed_raw:)
+    @effective = ProjectDescriptions.effective(current_project)
+    @lookups = (@effective['lookups'] || {}).sort.to_h
+    @version = ProjectDescriptions.version(current_project)
+    @raw_json = parsed_raw
+    render :edit, status: :unprocessable_entity
+  end
+end

--- a/app/models/project_descriptions.rb
+++ b/app/models/project_descriptions.rb
@@ -1,0 +1,88 @@
+# Per-project descriptions config: the static base (config/descriptions.json,
+# loaded once at boot into Rails.application.config.descriptions) merged with an
+# editable per-project override stored in CouchDB.
+#
+# A dig director edits the override on the web; the override doc is a singleton
+# (`_id: "descriptions"`) in the project's main db (mirroring Project metadata),
+# carrying the override hash plus a monotonically increasing `version` so clients
+# can detect changes.
+#
+# Effective = base.deep_merge(override): nested hashes merge, while arrays and
+# scalars from the override REPLACE the base — so an edited lookup list (e.g.
+# `designation`) wholly replaces the default list rather than concatenating.
+module ProjectDescriptions
+  OVERRIDE_DOC_ID = 'descriptions'.freeze
+
+  module_function
+
+  # The static, deploy-time descriptions (shared default for every project).
+  def base
+    Rails.application.config.descriptions
+  end
+
+  # The project's effective descriptions (base + override), cached by version.
+  def effective(project = CouchDB.current_project)
+    return base if project.blank?
+
+    doc = override_doc(project)
+    override = doc.is_a?(Hash) ? doc['descriptions'] : nil
+    return base if override.blank?
+
+    Rails.cache.fetch("descriptions_effective/#{project}/#{doc['version']}", expires_in: 1.hour) do
+      base.deep_merge(override)
+    end
+  end
+
+  # The override hash a dig director saved (the parts they changed), or {}.
+  def override(project = CouchDB.current_project)
+    doc = override_doc(project)
+    (doc.is_a?(Hash) ? doc['descriptions'] : nil) || {}
+  end
+
+  # The override version (0 when there is no override). Bumped on every save so
+  # clients (the device bundle) can detect a change.
+  def version(project = CouchDB.current_project)
+    doc = override_doc(project)
+    doc.is_a?(Hash) ? doc['version'].to_i : 0
+  end
+
+  # Store a new override hash for the project and bump the version. Returns the
+  # new version.
+  def save(project, override_descriptions)
+    db = CouchDB.main_db(project)
+    doc = db.get(OVERRIDE_DOC_ID) || { '_id' => OVERRIDE_DOC_ID, 'type' => 'descriptions', 'version' => 0 }
+    doc['descriptions'] = override_descriptions
+    doc['version'] = doc['version'].to_i + 1
+    doc['updated_at'] = Time.current.iso8601
+    db.save_doc(doc)
+    clear_cache(project)
+    doc['version']
+  end
+
+  # Remove the override so the project re-inherits the static defaults.
+  def reset(project)
+    db = CouchDB.main_db(project)
+    doc = db.get(OVERRIDE_DOC_ID)
+    db.delete_doc(doc) if doc
+    clear_cache(project)
+  end
+
+  # The raw override doc, cached briefly (and as a sentinel when absent) so the
+  # per-request set_descriptions doesn't hit CouchDB on every page load.
+  def override_doc(project)
+    cached = Rails.cache.read("descriptions_override/#{project}")
+    return cached == :none ? nil : cached unless cached.nil?
+
+    doc = begin
+      CouchDB.main_db(project).get(OVERRIDE_DOC_ID)
+    rescue StandardError
+      nil
+    end
+    Rails.cache.write("descriptions_override/#{project}", doc || :none, expires_in: 5.minutes)
+    doc
+  end
+
+  def clear_cache(project)
+    Rails.cache.delete("descriptions_override/#{project}")
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -329,6 +329,9 @@ class User
   # Assigning roles to users for the project.
   def can_manage_roles? = superuser? || dig_director?
 
+  # Editing the project's descriptions config (form fields & lookups).
+  def can_edit_descriptions? = superuser? || dig_director?
+
   # A dig director may assign any project role except superuser; only a superuser
   # can grant superuser.
   def can_assign_role?(target_role)

--- a/app/views/descriptions/edit.html.erb
+++ b/app/views/descriptions/edit.html.erb
@@ -1,0 +1,67 @@
+<div class="container mx-auto max-w-4xl px-2 py-8">
+  <div class="flex flex-wrap items-end justify-between gap-4 mb-2">
+    <div>
+      <h1 class="font-serif text-4xl text-[#2a231b]">Descriptions</h1>
+      <p class="text-[#6a5d4c] mt-1">
+        Form fields and lookup lists for <span class="font-medium"><%= current_project %></span>.
+        Changes apply to this project and sync to the mobile app.
+        <span class="text-[#9c8e78]">(version <%= @version %>)</span>
+      </p>
+    </div>
+    <% if @version.positive? %>
+      <%= button_to "Reset to defaults", descriptions_path, method: :delete,
+            form: { data: { turbo_confirm: "Discard this project's customisations and re-inherit the defaults?" } },
+            class: "inline-flex items-center rounded-full border border-[#d8a99a] px-4 py-2 text-sm font-medium text-[#9c2a1c] hover:bg-[#fdecea] cursor-pointer" %>
+    <% end %>
+  </div>
+
+  <div class="od-form">
+    <%# --- Lookup-list editor (friendly) ------------------------------------ %>
+    <section class="ls-section">
+      <h1>Lookup lists</h1>
+      <p class="text-sm text-[#6a5d4c] mb-4">One value per line. These feed the dropdowns and combo fields (e.g. find designation, material).</p>
+      <%= form_with url: descriptions_path, method: :patch, local: true do %>
+        <input type="hidden" name="mode" value="lookups">
+        <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <% @lookups.each do |name, values| %>
+            <div class="form-group">
+              <label for="lookup_<%= name %>"><%= name.to_s.tr('_', ' ').titleize %></label>
+              <textarea id="lookup_<%= name %>" name="lookups[<%= name %>]" rows="6"
+                        class="form-control font-mono text-sm"><%= Array(values).join("\n") %></textarea>
+            </div>
+          <% end %>
+        </div>
+        <div class="sticky bottom-0 -mx-2 mt-4 flex justify-end border-t border-[#ddcfb4] bg-[#fbf6ec]/95 px-4 py-3 backdrop-blur">
+          <%= submit_tag "Save lookup lists",
+                class: "inline-flex items-center rounded-full bg-[#b1542b] px-5 py-2 text-sm font-medium text-white shadow-sm hover:bg-[#8d3f1d] cursor-pointer border-0" %>
+        </div>
+      <% end %>
+    </section>
+
+    <%# --- Raw JSON editor (advanced) --------------------------------------- %>
+    <section class="ls-section">
+      <details>
+        <summary class="cursor-pointer font-serif text-lg font-semibold text-[#2a231b] hover:text-[#b1542b]">
+          Advanced: edit the full descriptions JSON
+        </summary>
+        <div class="mt-4">
+          <p class="text-sm text-[#9c2a1c] mb-3">
+            Editing the raw JSON replaces the whole descriptions document for this project.
+            A malformed edit is rejected on save; you can always Reset to defaults.
+          </p>
+          <%= form_with url: descriptions_path, method: :patch, local: true do %>
+            <input type="hidden" name="mode" value="raw">
+            <textarea name="raw_json" rows="24" spellcheck="false"
+                      class="form-control font-mono text-xs"><%= @raw_json %></textarea>
+            <div class="mt-3 flex justify-end">
+              <%= submit_tag "Save JSON",
+                    class: "inline-flex items-center rounded-full border border-[#b1542b] px-5 py-2 text-sm font-medium text-[#b1542b] hover:bg-[#fdecea] cursor-pointer bg-transparent" %>
+            </div>
+          <% end %>
+        </div>
+      </details>
+    </section>
+  </div>
+</div>
+
+<%= render 'shared/edit_form_theme' %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -67,6 +67,9 @@
               <% if current_user.can_manage_roles? %>
                 <li><%= link_to("Users", manage_users_admin_index_path, class: "hover:text-[#b1542b]") %></li>
               <% end %>
+              <% if current_user.can_edit_descriptions? %>
+                <li><%= link_to("Descriptions", edit_descriptions_path, class: "hover:text-[#b1542b]") %></li>
+              <% end %>
               <li><%= link_to((current_user.name.presence || "Account"), account_path, class: "hover:text-[#b1542b]") %></li>
               <li>
                 <%= button_to "Sign out",
@@ -127,6 +130,9 @@
             <% end %>
             <% if current_user.can_manage_roles? %>
               <li><%= link_to("Users", manage_users_admin_index_path, class: "block rounded px-3 py-2 hover:bg-[#efe3cf] hover:text-[#b1542b]") %></li>
+            <% end %>
+            <% if current_user.can_edit_descriptions? %>
+              <li><%= link_to("Descriptions", edit_descriptions_path, class: "block rounded px-3 py-2 hover:bg-[#efe3cf] hover:text-[#b1542b]") %></li>
             <% end %>
             <li><%= link_to((current_user.name.presence || "Account"), account_path, class: "block rounded px-3 py-2 hover:bg-[#efe3cf] hover:text-[#b1542b]") %></li>
             <li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -75,6 +75,8 @@ Rails.application.routes.draw do
     end
   end
 
+  resource :descriptions, only: %i[edit update destroy], controller: 'descriptions'
+
   resources :reports, only: %i[index show]
 
   root to: 'areas#index'

--- a/spec/controllers/descriptions_controller_spec.rb
+++ b/spec/controllers/descriptions_controller_spec.rb
@@ -1,0 +1,81 @@
+require 'rails_helper'
+
+RSpec.describe DescriptionsController, type: :controller do
+  let(:users) { load_user_fixtures }
+
+  before do
+    allow(controller).to receive(:set_db)
+    # check_editing_mode is the app-wide EDITING_ENABLED gate (on in prod);
+    # stub it so these tests isolate the descriptions authorization.
+    allow(controller).to receive(:check_editing_mode)
+    allow(ProjectDescriptions).to receive_messages(effective: { 'lookups' => { 'designation' => ['Bead'] }, 'description_types' => {} }, version: 0)
+  end
+
+  describe 'GET edit (dig-director gate)' do
+    it 'allows a dig director' do
+      session[:user_id] = users[:dig_director].id
+      get :edit
+      expect(response).to be_successful
+    end
+
+    it 'allows a superuser' do
+      session[:user_id] = users[:superuser].id
+      get :edit
+      expect(response).to be_successful
+    end
+
+    it 'denies a registrar' do
+      session[:user_id] = users[:registrar].id
+      get :edit
+      expect(response).to redirect_to(controller.root_path)
+    end
+
+    it 'denies a plain viewer' do
+      session[:user_id] = users[:viewer].id
+      get :edit
+      expect(response).to redirect_to(controller.root_path)
+    end
+  end
+
+  describe 'PATCH update' do
+    before { session[:user_id] = users[:dig_director].id }
+
+    it 'saves edited lookup lists (one value per line)' do
+      allow(ProjectDescriptions).to receive(:override).and_return({})
+      captured = nil
+      allow(ProjectDescriptions).to receive(:save) { |_project, override| captured = override }
+
+      patch :update, params: { mode: 'lookups', lookups: { 'designation' => "Bead\nMilestone\n" } }
+
+      expect(captured['lookups']['designation']).to eq(%w[Bead Milestone])
+      expect(response).to redirect_to(edit_descriptions_path)
+    end
+
+    it 'saves valid raw JSON' do
+      expect(ProjectDescriptions).to receive(:save)
+      patch :update, params: { mode: 'raw', raw_json: '{"lookups":{},"description_types":{}}' }
+      expect(response).to redirect_to(edit_descriptions_path)
+    end
+
+    it 'rejects malformed JSON' do
+      expect(ProjectDescriptions).not_to receive(:save)
+      patch :update, params: { mode: 'raw', raw_json: '{ not valid' }
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+
+    it 'rejects JSON missing required keys' do
+      expect(ProjectDescriptions).not_to receive(:save)
+      patch :update, params: { mode: 'raw', raw_json: '{"foo":1}' }
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+  end
+
+  describe 'DELETE destroy' do
+    it 'resets the project to the defaults' do
+      session[:user_id] = users[:dig_director].id
+      expect(ProjectDescriptions).to receive(:reset)
+      delete :destroy
+      expect(response).to redirect_to(edit_descriptions_path)
+    end
+  end
+end


### PR DESCRIPTION
## What

Dig directors (and superusers) can now edit their project's **descriptions** config directly from the web app. Each project's edits layer over the shared static defaults (`config/descriptions.json`), so one project's changes never affect another.

## How

- **`ProjectDescriptions`** — the static base merged with an editable per-project override stored as a singleton CouchDB doc (`_id: "descriptions"`, mirroring `Project.metadata`). Effective = `base.deep_merge(override)` (edited lookup lists replace the default list rather than concatenating). Carries a monotonically increasing `version` so clients (the device bundle) can detect changes. Override doc + effective merge are cached.
- **`DescriptionsController`** — two editing modes:
  - **Lookups**: friendly per-list editor (one value per line) for the lookup value lists (designation, material, …).
  - **Raw**: validated JSON editor for the whole descriptions document.
  - **Reset**: drops the override so the project re-inherits the defaults.
- **`can_edit_descriptions?`** capability (superuser or dig director), gating the controller, a new nav link, and the `resource :descriptions` route. `application_controller` now serves the *effective* descriptions for the current project.

## Notes

- This is increment 1 (web editor + per-project store + merged rendering). Increment 2 will surface the per-project descriptions + `version` in the device bundle and add mobile change-detection so devices auto-update.

## Test plan

- `spec/controllers/descriptions_controller_spec.rb`: dig-director/superuser allowed; registrar/viewer denied; lookups save (one value per line); raw JSON valid/invalid/missing-keys; reset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)