### PR TITLE
Per-project descriptions + version in the device bundle

### DIFF
--- a/app/services/device_configuration.rb
+++ b/app/services/device_configuration.rb
@@ -19,7 +19,10 @@ class DeviceConfiguration
       'imgproxy' => imgproxy_config,
       'couchdb' => couchdb_config,
       's3' => s3_config,
-      'descriptions' => Rails.application.config.descriptions,
+      # Shared base descriptions (the deploy-time defaults). Each project entry
+      # may carry its own effective `descriptions` + `descriptions_version`; the
+      # device uses the per-project map when present and falls back to this base.
+      'descriptions' => ProjectDescriptions.base,
       'projects' => projects
     }
   end
@@ -35,7 +38,7 @@ class DeviceConfiguration
   def projects
     superuser = @user.superuser?
     project_keys.map do |key|
-      {
+      entry = {
         'key' => key,
         'name' => Project.display_name(key),
         'description' => Project.description(key),
@@ -47,7 +50,20 @@ class DeviceConfiguration
         'database' => Project.database_name(key),
         'storage' => storage_prefixes(key)
       }
+      entry.merge!(descriptions_for(key))
     end
+  end
+
+  # Per-project descriptions: always report the override `version` (0 when the
+  # project has no override) so the device can cheaply detect a change. Only ship
+  # the full effective `descriptions` map when the project actually overrides the
+  # defaults — otherwise the device falls back to the top-level base, keeping the
+  # bundle small for the common (unmodified) case.
+  def descriptions_for(key)
+    version = ProjectDescriptions.version(key)
+    out = { 'descriptions_version' => version }
+    out['descriptions'] = ProjectDescriptions.effective(key) if version.positive?
+    out
   end
 
   # Where this project's files live in the shared bucket. Resolved through

--- a/spec/services/device_configuration_spec.rb
+++ b/spec/services/device_configuration_spec.rb
@@ -57,4 +57,27 @@ RSpec.describe DeviceConfiguration do
     expect(config['descriptions']).to be_present
     expect(config['user']).to include('email', 'name')
   end
+
+  describe 'per-project descriptions' do
+    it 'reports a version for every project and omits the map when unoverridden' do
+      allow(ProjectDescriptions).to receive(:version).and_return(0)
+      config = described_class.new(users[:superuser]).as_json
+
+      config['projects'].each do |project|
+        expect(project['descriptions_version']).to eq(0)
+        expect(project).not_to have_key('descriptions')
+      end
+    end
+
+    it 'ships the effective map and version for an overridden project' do
+      effective = { 'lookups' => { 'designation' => %w[Bead Milestone] }, 'description_types' => {} }
+      allow(ProjectDescriptions).to receive(:version).and_return(0)
+      allow(ProjectDescriptions).to receive(:version).with('opendig').and_return(3)
+      allow(ProjectDescriptions).to receive(:effective).with('opendig').and_return(effective)
+
+      opendig = described_class.new(users[:superuser]).as_json['projects'].find { |p| p['key'] == 'opendig' }
+      expect(opendig['descriptions_version']).to eq(3)
+      expect(opendig['descriptions']).to eq(effective)
+    end
+  end
 end


### PR DESCRIPTION
## What

Increment 2 (server half) of the descriptions editor: surface each project's **effective descriptions** and a **version** in the device configuration bundle so paired mobile devices can detect and pick up description changes per project.

## How

- Each `projects[]` entry now carries `descriptions_version` (0 when the project has no override) so the device can cheaply detect a change without diffing the whole map.
- The full effective `descriptions` map is only included for a project that actually overrides the defaults — otherwise the device falls back to the top-level base, keeping the bundle small for the common unmodified case.
- Top-level `descriptions` is now explicitly `ProjectDescriptions.base` (the shared deploy-time defaults), documented as the fallback.

## Test plan

- `spec/services/device_configuration_spec.rb`: every project reports a version and omits the map when unoverridden; an overridden project ships its effective map + version.

## Follow-up

- Mobile change-detection (compare per-project version, re-apply + refresh open screens only on change) ships via the next app build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)